### PR TITLE
Add API reference documentation for array-update

### DIFF
--- a/api-reference/operators/array-update/$.md
+++ b/api-reference/operators/array-update/$.md
@@ -1,0 +1,226 @@
+---
+title: $
+description: The $ positional operator identifies an element in an array to update without explicitly specifying the position of the element in the array.
+type: operators
+category: array-update
+---
+
+# $
+
+The `$` positional operator identifies an element in an array to update without explicitly specifying the position of the element in the array. The `$` operator acts as a placeholder for the first element that matches the query condition, and the array field must appear as part of the query document.
+
+## Syntax
+
+```javascript
+db.collection.updateOne(
+  { <array>: <value> },
+  { <update operator>: { "<array>.$": <value> } }
+)
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`array`** | The array field that contains the element to update. Must be part of the query condition. |
+| **`value`** | The value used to match the array element in the query condition. |
+| **`update operator`** | The update operator to apply (for example, `$set`, `$inc`, `$unset`). |
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "location": {
+        "lat": -89.2384,
+        "lon": -46.4012
+    },
+    "staff": {
+        "totalStaff": {
+            "fullTime": 8,
+            "partTime": 20
+        }
+    },
+    "sales": {
+        "totalSales": 75670,
+        "salesByCategory": [
+            {
+                "categoryName": "Wine Accessories",
+                "totalSales": 34440
+            },
+            {
+                "categoryName": "Bitters",
+                "totalSales": 39496
+            },
+            {
+                "categoryName": "Rum",
+                "totalSales": 1734
+            }
+        ]
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Unbeatable Bargain Bash",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 7
+                },
+                {
+                    "categoryName": "Bitters",
+                    "discountPercentage": 15
+                },
+                {
+                    "categoryName": "Brandy",
+                    "discountPercentage": 8
+                },
+                {
+                    "categoryName": "Sports Drinks",
+                    "discountPercentage": 22
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Steal of a Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 29
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Organic Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "White Wine",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Sparkling Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 17
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 23
+                }
+            ]
+        }
+    ]
+}
+```
+
+### Example 1: Project the first element of an array, matching the condition
+
+This query returns the first element within the `salesByCategory` array, for `DJ` equipment with `totalSales` greater than 35000.
+
+```javascript
+db.stores.find({
+    "sales.salesByCategory": {
+        $elemMatch: {
+            categoryName: {
+                $regex: "^DJ"
+            }
+        }
+    },
+    "sales.salesByCategory.totalSales": {
+        $gt: 35000
+    }
+}, {
+    "sales.salesByCategory.$": 1
+}).limit(2)
+```
+
+The first two results returned by this query are:
+
+```json
+[
+  {
+    "_id": "d3c9df51-41bd-4b4e-a26b-b038d9cf8b45",
+    "sales": {
+      "salesByCategory": [
+        {
+          "categoryName": "DJ Speakers",
+          "totalSales": 36972
+        }
+      ]
+    }
+  },
+  {
+    "_id": "7954bd5c-9ac2-4c10-bb7a-2b79bd0963c5",
+    "sales": {
+      "salesByCategory": [
+        {
+          "categoryName": "DJ Headphones",
+          "totalSales": 35911
+        }
+      ]
+    }
+  }
+]
+```
+
+### Example 2: Update discount percentage for a specific category
+
+This query updates the discount percentage for "Desks" category in the first matching promotion event.
+
+```javascript
+db.stores.updateOne(
+  { 
+    _id: "905d1939-e03a-413e-a9c4-221f74055aac",
+    "promotionEvents.discounts.categoryName": "Desks"
+  },
+  {
+    $set: { "promotionEvents.$.discounts.$[elem].discountPercentage": 25 }
+  },
+  {
+    arrayFilters: [{ "elem.categoryName": "Desks" }]
+  }
+)
+```
+
+### Example 3: Update sales category total
+
+This query updates the total sales for a specific category using the `$ (positional operator)`.
+
+```javascript
+db.stores.updateOne(
+  { 
+    _id: "905d1939-e03a-413e-a9c4-221f74055aac",
+    "sales.salesByCategory.categoryName": "Desk Lamps"
+  },
+  {
+    $inc: { "sales.salesByCategory.$.totalSales": 1000 }
+  }
+)
+```

--- a/api-reference/operators/array-update/$addtoset.md
+++ b/api-reference/operators/array-update/$addtoset.md
@@ -1,0 +1,282 @@
+---
+title: $addToSet
+description: The addToSet operator adds elements to an array if they don't already exist, while ensuring uniqueness of elements within the set.
+type: operators
+category: array-update
+---
+
+# $addToSet
+
+The `$addToSet` operator adds elements to an array if they don't already exist, while ensuring uniqueness of elements within the set.
+
+## Syntax
+
+```javascript
+{
+  $addToSet: { <field1>: <value1> }
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`<field1>`** | The field to which you want to add elements. |
+| **`<value1>`** | The value to be added to the array. |
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "location": {
+        "lat": -89.2384,
+        "lon": -46.4012
+    },
+    "staff": {
+        "totalStaff": {
+            "fullTime": 8,
+            "partTime": 20
+        }
+    },
+    "sales": {
+        "totalSales": 75670,
+        "salesByCategory": [
+            {
+                "categoryName": "Wine Accessories",
+                "totalSales": 34440
+            },
+            {
+                "categoryName": "Bitters",
+                "totalSales": 39496
+            },
+            {
+                "categoryName": "Rum",
+                "totalSales": 1734
+            }
+        ]
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Unbeatable Bargain Bash",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 7
+                },
+                {
+                    "categoryName": "Bitters",
+                    "discountPercentage": 15
+                },
+                {
+                    "categoryName": "Brandy",
+                    "discountPercentage": 8
+                },
+                {
+                    "categoryName": "Sports Drinks",
+                    "discountPercentage": 22
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Steal of a Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 29
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Organic Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "White Wine",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Sparkling Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 17
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 23
+                }
+            ]
+        }
+    ]
+}
+```
+
+### Example 1: Add a new tag to the `tag` array
+
+This query adds a new tag to the array of tags, run a query using the $addToSet operator to add the new value.
+
+```javascript
+db.stores.updateOne({
+    _id: "0fcc0bf0-ed18-4ab8-b558-9848e18058f4"
+}, {
+    $addToSet: {
+        tag: "#ShopLocal"
+    }
+})
+```
+
+This query returns the following result:
+
+```json
+[
+  {
+    "acknowledged": true,
+    "insertedId": null,
+    "matchedCount": "1",
+    "modifiedCount": "0",
+    "upsertedCount": 0
+  }
+]
+```
+
+### Example 2: Adding a new promotional event to the `promotionEvents` array
+
+This query adds a new event to the `promotionEvents` array, run a query using the $addToSet operator with the new promotion object to be added.
+
+```javascript
+db.stores.updateOne({
+    _id: "0fcc0bf0-ed18-4ab8-b558-9848e18058f4"
+}, {
+    $addToSet: {
+        promotionEvents: {
+            eventName: "Summer Sale",
+            promotionalDates: {
+                startDate: {
+                    Year: 2024,
+                    Month: 6,
+                    Day: 1
+                },
+                endDate: {
+                    Year: 2024,
+                    Month: 6,
+                    Day: 15
+                }
+            },
+            discounts: [{
+                categoryName: "DJ Speakers",
+                discountPercentage: 20
+            }]
+        }
+    }
+})
+```
+
+This query returns the following result:
+
+```json
+[
+  {
+    "acknowledged": true,
+    "insertedId": null,
+    "matchedCount": "1",
+    "modifiedCount": "1",
+    "upsertedCount": 0
+  }
+]
+```
+
+### Example 3 - Using $addToSet with $setWindowOperators
+
+To retrieve the list of cities for each store within the "First Up Consultants" company, run a query to first partition stores by the company. Then, use the $addToSet operator to add the distinct cities for each store within the partition.
+
+```javascript
+db.stores.aggregate([{
+    $match: {
+        company: {
+            $in: ["First Up Consultants"]
+        }
+    }
+}, {
+    $setWindowFields: {
+        partitionBy: "$company",
+        sortBy: {
+            "sales.totalSales": -1
+        },
+        output: {
+            citiesForCompany: {
+                $push: "$city",
+                window: {
+                    documents: ["unbounded", "current"]
+                }
+            }
+        }
+    }
+}, {
+    $project: {
+        company: 1,
+        name: 1,
+        citiesForCompany: 1
+    }
+}])
+```
+
+The first two results returned by this query are:
+
+```json
+[
+    {
+        "_id": "a1713bed-4c8b-46e7-bb68-259045dffdb4",
+        "name": "First Up Consultants | Bed and Bath Collection - Jaskolskiside",
+        "company": "First Up Consultants",
+        "citiesForCompany": [
+            "South Thelma",
+            "South Carmenview",
+            "Port Antone",
+            "Charlotteville",
+            "South Lenorafort",
+            "Jaskolskiside"
+        ]
+    },
+    {
+        "_id": "6b8585ab-4357-4da7-8625-f6a1cd5796c5",
+        "name": "First Up Consultants | Computer Depot - West Zack",
+        "company": "First Up Consultants",
+        "citiesForCompany": [
+            "South Thelma",
+            "South Carmenview",
+            "Port Antone",
+            "Charlotteville",
+            "South Lenorafort",
+            "Jaskolskiside",
+            "West Zack"
+        ]
+    }
+]
+```

--- a/api-reference/operators/array-update/$each.md
+++ b/api-reference/operators/array-update/$each.md
@@ -1,0 +1,198 @@
+---
+title: $each
+description: The $each operator is used within an `$addToSet` or `$push` operation to add multiple elements to an array field in a single update operation.
+type: operators
+category: array-update
+---
+
+# $each
+
+The `$each` operator is used within an `$addToSet` or `$push` operation to add multiple elements to an array field in a single update operation. This operator is useful when you need to insert multiple items into an array without having to perform multiple update operations. The `$each` operator ensures that each item in the specified array is added to the target array.
+
+## Syntax
+
+```javascript
+{
+  $push: {
+    <field>: {
+      $each: [ <value1>, <value2>],
+      <modifier1>: <value1>,
+      <modifier2>: <value2>
+    }
+  }
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`<field>`**| The field to be updated.|
+| **`$each`**| An array of values to be added to the array field.|
+| **`<modifier>`**| Optional modifiers like `$sort`, `$slice`, and `$position` to control the behavior of the `$push` operation.|
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "location": {
+        "lat": -89.2384,
+        "lon": -46.4012
+    },
+    "staff": {
+        "totalStaff": {
+            "fullTime": 8,
+            "partTime": 20
+        }
+    },
+    "sales": {
+        "totalSales": 75670,
+        "salesByCategory": [
+            {
+                "categoryName": "Wine Accessories",
+                "totalSales": 34440
+            },
+            {
+                "categoryName": "Bitters",
+                "totalSales": 39496
+            },
+            {
+                "categoryName": "Rum",
+                "totalSales": 1734
+            }
+        ]
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Unbeatable Bargain Bash",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 7
+                },
+                {
+                    "categoryName": "Bitters",
+                    "discountPercentage": 15
+                },
+                {
+                    "categoryName": "Brandy",
+                    "discountPercentage": 8
+                },
+                {
+                    "categoryName": "Sports Drinks",
+                    "discountPercentage": 22
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Steal of a Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 29
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Organic Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "White Wine",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Sparkling Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 17
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 23
+                }
+            ]
+        }
+    ]
+}
+```
+
+### Example 1: Add multiple elements to an array
+
+This query adds multiple new promotion events to the `promotionEvents` array.
+
+```javascript
+db.stores.updateOne({
+    name: "Lenore's New DJ Equipment Store"
+}, {
+    $push: {
+        promotionEvents: {
+            $each: [{
+                    eventName: "Grand Savings",
+                    promotionalDates: {
+                        startDate: "2024-08-01",
+                        endDate: "2024-08-31"
+                    },
+                    discounts: [{
+                        categoryName: "DJ Headphones",
+                        discountPercentage: 5
+                    }]
+                },
+                {
+                    eventName: "Big Bargain",
+                    promotionalDates: {
+                        startDate: "2024-11-25",
+                        endDate: "2024-11-30"
+                    },
+                    discounts: [{
+                        categoryName: "DJ Headphones",
+                        discountPercentage: 20
+                    }]
+                }
+            ]
+        }
+    }
+})
+```
+
+This query returns the following result.
+
+```json
+[
+  {
+    "acknowledged": true,
+    "insertedId": null,
+    "matchedCount": "0",
+    "modifiedCount": "0",
+    "upsertedCount": 0
+  }
+]
+```

--- a/api-reference/operators/array-update/$pop.md
+++ b/api-reference/operators/array-update/$pop.md
@@ -1,0 +1,198 @@
+---
+title: $pop
+description: Removes the first or last element of an array.
+type: operators
+category: array-update
+---
+
+# $pop
+
+The `$pop` operator is used to remove the first or last element of an array. This operator is useful when you need to manage arrays by removing elements from either end. The `$pop` operator can be used in update operations.
+
+## Syntax
+
+```javascript
+{
+  $pop: {
+    <field>: <value>
+  }
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`<field>`** | The field that contains the array from which you want to remove an element. |
+| **`<value>`** | Use `1` to remove the last element, and `-1` to remove the first element. |
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "location": {
+        "lat": -89.2384,
+        "lon": -46.4012
+    },
+    "staff": {
+        "totalStaff": {
+            "fullTime": 8,
+            "partTime": 20
+        }
+    },
+    "sales": {
+        "totalSales": 75670,
+        "salesByCategory": [
+            {
+                "categoryName": "Wine Accessories",
+                "totalSales": 34440
+            },
+            {
+                "categoryName": "Bitters",
+                "totalSales": 39496
+            },
+            {
+                "categoryName": "Rum",
+                "totalSales": 1734
+            }
+        ]
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Unbeatable Bargain Bash",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 7
+                },
+                {
+                    "categoryName": "Bitters",
+                    "discountPercentage": 15
+                },
+                {
+                    "categoryName": "Brandy",
+                    "discountPercentage": 8
+                },
+                {
+                    "categoryName": "Sports Drinks",
+                    "discountPercentage": 22
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Steal of a Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 29
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Organic Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "White Wine",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Sparkling Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 17
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 23
+                }
+            ]
+        }
+    ]
+}
+```
+
+### Example 1: Remove the last element from an array
+
+To remove the last element from the tag array, run a query using the $pop operator on the tag field with a value of 1.
+
+```javascript
+db.stores.update({
+    _id: "7954bd5c-9ac2-4c10-bb7a-2b79bd0963c5"
+}, {
+    $pop: {
+        tag: 1
+    }
+})
+```
+
+This query returns the following result.
+
+```json
+[
+  {
+    "acknowledged": true,
+    "insertedId": null,
+    "matchedCount": "1",
+    "modifiedCount": "1",
+    "upsertedCount": 0
+  }
+]
+
+```
+
+### Example 2: Removing the first element from an array
+
+To remove the first element from the promotionEvents array, run a query using the $pop operator on the promotionEvents array with a value of -1.
+
+```javascript
+db.stores.update({
+    _id: "7954bd5c-9ac2-4c10-bb7a-2b79bd0963c5"
+}, {
+    $pop: {
+        promotionEvents: -1
+    }
+})
+```
+
+This query returns the following result.
+
+```json
+[
+  {
+    "acknowledged": true,
+    "insertedId": null,
+    "matchedCount": "1",
+    "modifiedCount": "1",
+    "upsertedCount": 0
+  }
+]
+```

--- a/api-reference/operators/array-update/$pop.md
+++ b/api-reference/operators/array-update/$pop.md
@@ -1,6 +1,6 @@
 ---
 title: $pop
-description: Removes the first or last element of an array.
+description: The $pop operator removes the first or last element of an array.
 type: operators
 category: array-update
 ---

--- a/api-reference/operators/array-update/$positional-all.md
+++ b/api-reference/operators/array-update/$positional-all.md
@@ -1,0 +1,175 @@
+---
+title: $[]
+description: The $[] operator is used to update all elements in an array that match the query condition.
+type: operators
+category: array-update
+---
+
+# $[]
+
+The $[] operator in DocumentDB is used to update all elements in an array that match a specified condition. This operator allows you to perform updates on multiple elements in an array without specifying their positions. It is particularly useful when you need to apply the same update to all items in an array.
+
+## Syntax
+
+```javascript
+db.collection.update(
+   <query>,
+   {
+     $set: {
+       <arrayField>.$[]: <value>
+     }
+   }
+)
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`<query>`** | The selection criteria for the documents to update. |
+| **`<arrayField>`** | The field containing the array to update. |
+| **`<value>`** | The value to set for each matching element in the array. |
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "location": {
+        "lat": -89.2384,
+        "lon": -46.4012
+    },
+    "staff": {
+        "totalStaff": {
+            "fullTime": 8,
+            "partTime": 20
+        }
+    },
+    "sales": {
+        "totalSales": 75670,
+        "salesByCategory": [
+            {
+                "categoryName": "Wine Accessories",
+                "totalSales": 34440
+            },
+            {
+                "categoryName": "Bitters",
+                "totalSales": 39496
+            },
+            {
+                "categoryName": "Rum",
+                "totalSales": 1734
+            }
+        ]
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Unbeatable Bargain Bash",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 7
+                },
+                {
+                    "categoryName": "Bitters",
+                    "discountPercentage": 15
+                },
+                {
+                    "categoryName": "Brandy",
+                    "discountPercentage": 8
+                },
+                {
+                    "categoryName": "Sports Drinks",
+                    "discountPercentage": 22
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Steal of a Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 29
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Organic Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "White Wine",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Sparkling Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 17
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 23
+                }
+            ]
+        }
+    ]
+}
+```
+
+### Example 1: Updating Discount Percentages
+
+This query updates all elements in the discounts array inside each promotion event.
+
+```javascript
+db.stores.updateOne(
+  { _id: "905d1939-e03a-413e-a9c4-221f74055aac" },
+  {
+    $inc: {
+      "promotionEvents.$[].discounts.$[].discountPercentage": 5
+    }
+  }
+)
+```
+
+### Example 2: Updating Sales by Category
+
+This query increase the total sales for all categories by 10% by using the $[] operator.
+
+```javascript
+db.stores.update(
+  { _id: "905d1939-e03a-413e-a9c4-221f74055aac" },
+  {
+    $mul: {
+      "sales.salesByCategory.$[].totalSales": 1.10
+    }
+  }
+)
+```

--- a/api-reference/operators/array-update/$positional-filtered.md
+++ b/api-reference/operators/array-update/$positional-filtered.md
@@ -1,0 +1,225 @@
+---
+title: $[identifier]
+description: The $[] operator is used to update all elements using a specific identifier in an array that match the query condition.
+type: operators
+category: array-update
+---
+
+# $[identifier]
+
+The $[identifier] array update operator is used to update specific elements in an array that match a given condition. This operator is useful when you need to update multiple elements within an array based on certain criteria. It allows for more granular updates within documents, making it a powerful tool for managing complex data structures.
+
+## Syntax
+
+```javascript
+{
+  <update operator>: {
+    <array field>.$[<identifier>]: <value>
+  }
+},
+{
+  arrayFilters: [
+    { <identifier>.<field>: <condition> }
+  ]
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`<update operator>`** | The update operator to be applied (for example, `$set`, `$inc`, etc.). |
+| **`<array field>`** | The field containing the array to be updated. |
+| **`<identifier>`** | A placeholder used in `arrayFilters` to match specific elements in the array. |
+| **`<value>`** | The value to be set or updated. |
+| **`arrayFilters`** | An array of filter conditions to identify which elements to update. |
+| **`<field>`** | The specific field within array elements to be checked. |
+| **`<condition>`** | The condition that array elements must meet to be updated. |
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "905d1939-e03a-413e-a9c4-221f74055aac",
+    "name": "Trey Research | Home Office Depot - Lake Freeda",
+    "location": {
+        "lat": -48.9752,
+        "lon": -141.6816
+    },
+    "staff": {
+        "employeeCount": {
+            "fullTime": 12,
+            "partTime": 19
+        }
+    },
+    "sales": {
+        "salesByCategory": [
+            {
+                "categoryName": "Desk Lamps",
+                "totalSales": 37978
+            }
+        ],
+        "revenue": 37978
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Crazy Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2023,
+                    "Month": 9,
+                    "Day": 27
+                },
+                "endDate": {
+                    "Year": 2023,
+                    "Month": 10,
+                    "Day": 4
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Desks",
+                    "discountPercentage": 25
+                },
+                {
+                    "categoryName": "Filing Cabinets",
+                    "discountPercentage": 23
+                }
+            ]
+        },
+        {
+            "eventName": "Incredible Markdown Mania",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2023,
+                    "Month": 12,
+                    "Day": 26
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 1,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Monitor Stands",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Desks",
+                    "discountPercentage": 24
+                }
+            ]
+        },
+        {
+            "eventName": "Major Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 3,
+                    "Day": 25
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 4,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Office Accessories",
+                    "discountPercentage": 9
+                },
+                {
+                    "categoryName": "Desks",
+                    "discountPercentage": 13
+                }
+            ]
+        },
+        {
+            "eventName": "Blowout Bonanza",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Office Chairs",
+                    "discountPercentage": 24
+                },
+                {
+                    "categoryName": "Desk Lamps",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Super Saver Fiesta",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 10,
+                    "Day": 1
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Desks",
+                    "discountPercentage": 5
+                },
+                {
+                    "categoryName": "Monitor Stands",
+                    "discountPercentage": 10
+                }
+            ]
+        }
+    ],
+    "company": "Trey Research",
+    "city": "Lake Freeda",
+    "storeOpeningDate": "2024-12-30T22:55:25.779Z",
+    "lastUpdated": {
+        "t": 1729983325,
+        "i": 1
+    }
+}
+```
+
+### Example 1: Update the discount percentage for the chosen category in the specified promotion event.
+
+This query updates the discount percentage for the 'Desk Lamps' category by modifying the specific elements in the promotion event array where the event name is 'Blowout Bonanza'.
+
+```javascript
+db.stores.updateOne(
+  {
+    _id: "905d1939-e03a-413e-a9c4-221f74055aac",
+    "promotionEvents.eventName": "Blowout Bonanza"
+  },
+  {
+    $set: {
+      "promotionEvents.$[event].discounts.$[discount].discountPercentage": 18
+    }
+  },
+  {
+    arrayFilters: [
+      { "event.eventName": "Blowout Bonanza" },
+      { "discount.categoryName": "Desk Lamps" }
+    ]
+  }
+)
+```

--- a/api-reference/operators/array-update/$positional-filtered.md
+++ b/api-reference/operators/array-update/$positional-filtered.md
@@ -1,5 +1,5 @@
 ---
-title: $[identifier]
+title: $[]
 description: The $[] operator is used to update all elements using a specific identifier in an array that match the query condition.
 type: operators
 category: array-update

--- a/api-reference/operators/array-update/$positional.md
+++ b/api-reference/operators/array-update/$positional.md
@@ -1,0 +1,178 @@
+---
+title: $position
+description: The $position is used to specify the position in the array where a new element should be inserted.
+type: operators
+category: array-update
+---
+
+# $position
+
+The `$position` operator is used to specify the position in the array where a new element should be inserted. This operator is useful when you need to insert an element at a specific index in an array rather than appending it to the end.
+
+## Syntax
+
+```javascript
+{
+  $push: {
+    <arrayField>: {
+      $each: [<value1>, <value2>],
+      $position: <index>
+    }
+  }
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`<arrayField>`**| The field in the document that contains the array to be updated.|
+| **`<value1>, <value2>, ...`**| The values to be inserted into the array.|
+| **`<index>`**| The position at which the values should be inserted.|
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "location": {
+        "lat": -89.2384,
+        "lon": -46.4012
+    },
+    "staff": {
+        "totalStaff": {
+            "fullTime": 8,
+            "partTime": 20
+        }
+    },
+    "sales": {
+        "totalSales": 75670,
+        "salesByCategory": [
+            {
+                "categoryName": "Wine Accessories",
+                "totalSales": 34440
+            },
+            {
+                "categoryName": "Bitters",
+                "totalSales": 39496
+            },
+            {
+                "categoryName": "Rum",
+                "totalSales": 1734
+            }
+        ]
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Unbeatable Bargain Bash",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 7
+                },
+                {
+                    "categoryName": "Bitters",
+                    "discountPercentage": 15
+                },
+                {
+                    "categoryName": "Brandy",
+                    "discountPercentage": 8
+                },
+                {
+                    "categoryName": "Sports Drinks",
+                    "discountPercentage": 22
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Steal of a Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 29
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Organic Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "White Wine",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Sparkling Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 17
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 23
+                }
+            ]
+        }
+    ]
+}
+```
+
+### Example 1: Insert an element at specific index location in an array field
+
+This query inserts the tag `#NewArrival` at the second position (index 1) in the `tag` array of a specific document.
+
+```javascript
+db.stores.update({
+    _id: "7954bd5c-9ac2-4c10-bb7a-2b79bd0963c5"
+}, {
+    $push: {
+        tag: {
+            $each: ["#NewArrival"],
+            $position: 1
+        }
+    }
+})
+```
+
+The updated document has the following values in the tag array.
+
+```json
+{
+  "_id": "7954bd5c-9ac2-4c10-bb7a-2b79bd0963c5",
+  "tag": [
+    "#ShopLocal",
+    "#NewArrival",
+    "#FashionStore",
+    "#SeasonalSale",
+    "#FreeShipping",
+    "#MembershipDeals"
+  ]
+}
+```

--- a/api-reference/operators/array-update/$pull.md
+++ b/api-reference/operators/array-update/$pull.md
@@ -1,0 +1,201 @@
+---
+title: $pull
+description: Removes all instances of a value from an array.
+type: operators
+category: array-update
+---
+
+# $pull
+
+The `$pull` operator is used to remove all instances of a specified value or values that match a condition from an array. This is useful when you need to clean up or modify array data within your documents.
+
+## Syntax
+
+```javascript
+{
+  $pull: { <field>: <value|condition> }
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`<field>`** | The field from which to remove one or more values. |
+| **`<value|condition>`** | The value or condition to remove from the array. |
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "location": {
+        "lat": -89.2384,
+        "lon": -46.4012
+    },
+    "staff": {
+        "totalStaff": {
+            "fullTime": 8,
+            "partTime": 20
+        }
+    },
+    "sales": {
+        "totalSales": 75670,
+        "salesByCategory": [
+            {
+                "categoryName": "Wine Accessories",
+                "totalSales": 34440
+            },
+            {
+                "categoryName": "Bitters",
+                "totalSales": 39496
+            },
+            {
+                "categoryName": "Rum",
+                "totalSales": 1734
+            }
+        ]
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Unbeatable Bargain Bash",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 7
+                },
+                {
+                    "categoryName": "Bitters",
+                    "discountPercentage": 15
+                },
+                {
+                    "categoryName": "Brandy",
+                    "discountPercentage": 8
+                },
+                {
+                    "categoryName": "Sports Drinks",
+                    "discountPercentage": 22
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Steal of a Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 29
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Organic Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "White Wine",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Sparkling Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 17
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 23
+                }
+            ]
+        }
+    ]
+}
+```
+
+### Example 1: Remove a specific tag from the `tag` array
+
+To remove the value "#SeasonalSale" from the tag array field, run a query using the $pull operator on the tag field.
+
+```javascript
+db.stores.update({
+    _id: "7954bd5c-9ac2-4c10-bb7a-2b79bd0963c5"
+}, {
+    $pull: {
+        tag: "#SeasonalSale"
+    }
+})
+```
+
+This query returns the following result.
+
+```json
+[
+  {
+    "acknowledged": true,
+    "insertedId": null,
+    "matchedCount": "1",
+    "modifiedCount": "1",
+    "upsertedCount": 0
+  }
+]
+```
+
+### Example 2: Remove all events from the `promotionEvents` array that end before a certain date
+
+To remove all elements from the promotionEvents array where the endDate year is 2024 and the endDate month is earlier than March, run a query using the $pull operator on the promotionEvents field with the specified date values.
+
+```javascript
+db.stores.update({
+            _id: "7954bd5c-9ac2-4c10-bb7a-2b79bd0963c5"
+        }, {
+            $pull: {
+                promotionEvents: {
+                    "promotionalDates.endDate.Year": 2024,
+                    "promotionalDates.endDate.Month": {
+                        $lt: 3
+                    }
+                }
+            }
+        }
+)
+```
+
+This query returns the following result.
+
+```json
+[
+  {
+    "acknowledged": true,
+    "insertedId": null,
+    "matchedCount": "1",
+    "modifiedCount": "1",
+    "upsertedCount": 0
+  }
+]
+```

--- a/api-reference/operators/array-update/$pullall.md
+++ b/api-reference/operators/array-update/$pullall.md
@@ -1,0 +1,171 @@
+---
+title: $pullAll
+description: The $pullAll operator is used to remove all instances of the specified values from an array.
+type: operators
+category: array-update
+---
+
+# $pullAll
+
+The `$pullAll` operator is used to remove all instances of the specified values from an array. This operator is useful when you need to clean up arrays by removing multiple specific elements in a single operation.
+
+Both `$pull` and `$pullAll` are used to remove elements from an array, but they differ in how they identify the elements to be removed. `$pull` removes all elements from an array that match a specific condition, which can be a simple value or a more complex query (like matching sub-document fields). On the other hand, `$pullAll` removes specific values provided as an array of exact matches, but it doesn't support conditions or queries. Essentially, `$pull` is more flexible as it allows conditional removal based on various criteria, while `$pullAll` is simpler, working only with a fixed set of values.
+
+## Syntax
+
+```javascript
+{
+  $pullAll: { <field1>: [ <value1>, <value2>] }
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`<field1>`**| The field where the specified values will be removed.|
+| **`[ <value1>, <value2>, ... ]`**| An array of values to be removed from the specified field.|
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "location": {
+        "lat": -89.2384,
+        "lon": -46.4012
+    },
+    "staff": {
+        "totalStaff": {
+            "fullTime": 8,
+            "partTime": 20
+        }
+    },
+    "sales": {
+        "totalSales": 75670,
+        "salesByCategory": [
+            {
+                "categoryName": "Wine Accessories",
+                "totalSales": 34440
+            },
+            {
+                "categoryName": "Bitters",
+                "totalSales": 39496
+            },
+            {
+                "categoryName": "Rum",
+                "totalSales": 1734
+            }
+        ]
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Unbeatable Bargain Bash",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 7
+                },
+                {
+                    "categoryName": "Bitters",
+                    "discountPercentage": 15
+                },
+                {
+                    "categoryName": "Brandy",
+                    "discountPercentage": 8
+                },
+                {
+                    "categoryName": "Sports Drinks",
+                    "discountPercentage": 22
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Steal of a Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 29
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Organic Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "White Wine",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Sparkling Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 17
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 23
+                }
+            ]
+        }
+    ]
+}
+```
+
+### Example 1: Remove multiple elements from an array
+
+To remove the discounts for "#MembershipDeals" and "#SeasonalSale" from the 'tag' array, run a query using the $pulAll operator on the tag field with the values to remove.
+
+```javascript
+db.stores.updateMany(
+    //filter
+    { _id: "7954bd5c-9ac2-4c10-bb7a-2b79bd0963c5"},
+    {
+      $pullAll: {
+        tag: ["#MembershipDeals","#SeasonalSale" ]
+      }
+    }
+)
+```
+
+This query returns the following result.
+
+```json
+[
+  {
+    "acknowledged": true,
+    "insertedId": null,
+    "matchedCount": 1,
+    "modifiedCount": 1,
+    "upsertedCount": 0
+  }
+]
+```

--- a/api-reference/operators/array-update/$push.md
+++ b/api-reference/operators/array-update/$push.md
@@ -1,0 +1,243 @@
+---
+title: $push
+description: The $push operator adds a specified value to an array within a document.
+type: operators
+category: array-update
+---
+
+# $push
+
+The `$push` operator is used to add a specified value to an array within a document. The $push operator adds new elements to an existing array without affecting other elements in the array.
+
+## Syntax
+
+```javascript
+db.collection.update({
+    < query >
+}, {
+    $push: {
+        < field >: < value >
+    }
+}, {
+    < options >
+})
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`<query>`**| The selection criteria for the documents to update.|
+| **`<field>`**| The array field to which the value will be appended.|
+| **`<value>`**| The value to append to the array field.|
+| **`<options>`**| Optional. Additional options for the update operation.|
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "location": {
+        "lat": -89.2384,
+        "lon": -46.4012
+    },
+    "staff": {
+        "totalStaff": {
+            "fullTime": 8,
+            "partTime": 20
+        }
+    },
+    "sales": {
+        "totalSales": 75670,
+        "salesByCategory": [
+            {
+                "categoryName": "Wine Accessories",
+                "totalSales": 34440
+            },
+            {
+                "categoryName": "Bitters",
+                "totalSales": 39496
+            },
+            {
+                "categoryName": "Rum",
+                "totalSales": 1734
+            }
+        ]
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Unbeatable Bargain Bash",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 7
+                },
+                {
+                    "categoryName": "Bitters",
+                    "discountPercentage": 15
+                },
+                {
+                    "categoryName": "Brandy",
+                    "discountPercentage": 8
+                },
+                {
+                    "categoryName": "Sports Drinks",
+                    "discountPercentage": 22
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Steal of a Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 29
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Organic Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "White Wine",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Sparkling Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 17
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 23
+                }
+            ]
+        }
+    ]
+}
+```
+
+### Example 1 - Add a new sales category
+
+To add a new sales category to the salesByCategory array, run a query using the $push operator on the field with a new Sales object with the name of the category and its sales volume.
+
+```javascript
+db.stores.update({
+    _id: "0fcc0bf0-ed18-4ab8-b558-9848e18058f4"
+}, {
+    $push: {
+        "sales.salesByCategory": {
+            categoryName: "Wine Accessories",
+            totalSales: 1000.00
+        }
+    }
+})
+```
+
+This query returns the following result:
+
+```json
+[
+  {
+    "acknowledged": true,
+    "insertedId": null,
+    "matchedCount": "1",
+    "modifiedCount": "1",
+    "upsertedCount": 0
+  }
+]
+```
+
+### Example 2 - Using $push with $setWindowFields
+
+To retrieve the distinct sales volumes across all stores under the "First Up Consultants" company, first run a query to partition stores within the company. Then, use the $push operator to create a list of sales from the first to the current store within the partition.
+
+```javascript
+db.stores.aggregate([{
+    $match: {
+        company: {
+            $in: ["First Up Consultants"]
+        }
+    }
+}, {
+    $setWindowFields: {
+        partitionBy: "$company",
+        sortBy: {
+            "sales.totalSales": -1
+        },
+        output: {
+            salesByStore: {
+                $push: "$sales.totalSales",
+                window: {
+                    documents: ["unbounded", "current"]
+                }
+            }
+        }
+    }
+}, {
+    $project: {
+        company: 1,
+        salesByStore: 1
+    }
+}])
+```
+
+The first three results returned by this query are:
+
+```json
+[
+    {
+        "_id": "a0386810-b6f8-4b05-9d60-e536fb2b0026",
+        "company": "First Up Consultants",
+        "salesByStore": [
+            327583
+        ]
+    },
+    {
+        "_id": "ad8af64a-d5bb-4162-9bb6-e5104126566d",
+        "company": "First Up Consultants",
+        "salesByStore": [
+            327583,
+            288582
+        ]
+    },
+    {
+        "_id": "39acb3aa-f350-41cb-9279-9e34c004415a",
+        "company": "First Up Consultants",
+        "salesByStore": [
+            327583,
+            288582,
+            279183
+        ]
+    }
+]
+```


### PR DESCRIPTION
Adds the API reference documentation for `array-update`. Includes the following files:

- `api-reference/operators/array-update/$.md`
- `api-reference/operators/array-update/$addtoset.md`
- `api-reference/operators/array-update/$each.md`
- `api-reference/operators/array-update/$pop.md`
- `api-reference/operators/array-update/$positional-all.md`
- `api-reference/operators/array-update/$positional-filtered.md`
- `api-reference/operators/array-update/$positional.md`
- `api-reference/operators/array-update/$pull.md`
- `api-reference/operators/array-update/$pullall.md`
- `api-reference/operators/array-update/$push.md`
- `api-reference/operators/array-update/index.md`

---

Depends on #4
