### PR TITLE
Add API reference documentation for bitwise-query

### DIFF
--- a/api-reference/operators/bitwise-query/$bitsAllClear.md
+++ b/api-reference/operators/bitwise-query/$bitsAllClear.md
@@ -1,0 +1,215 @@
+---
+title: $bitsAllClear
+description: The $bitsAllClear operator is used to match documents where all the bit positions specified in a bitmask are clear.
+type: operators
+category: bitwise-query
+---
+
+# $bitsAllClear
+
+The `$bitsAllClear` operator is used to match documents where all the bit positions specified in a bitmask are clear (that is, 0). This operator is useful in scenarios where you need to filter documents based on specific bits being unset in a binary representation of a field.
+
+## Syntax
+
+```javascript
+{
+  <field>: { $bitsAllClear: <bitmask> }
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`field`** | The field in the document on which the bitwise operation is to be performed.|
+| **`<bitmask>`** | A bitmask where each bit position specifies the corresponding bit position in the field's value that must be clear (0).|
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "location": {
+        "lat": -89.2384,
+        "lon": -46.4012
+    },
+    "staff": {
+        "totalStaff": {
+            "fullTime": 8,
+            "partTime": 20
+        }
+    },
+    "sales": {
+        "totalSales": 75670,
+        "salesByCategory": [
+            {
+                "categoryName": "Wine Accessories",
+                "totalSales": 34440
+            },
+            {
+                "categoryName": "Bitters",
+                "totalSales": 39496
+            },
+            {
+                "categoryName": "Rum",
+                "totalSales": 1734
+            }
+        ]
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Unbeatable Bargain Bash",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 7
+                },
+                {
+                    "categoryName": "Bitters",
+                    "discountPercentage": 15
+                },
+                {
+                    "categoryName": "Brandy",
+                    "discountPercentage": 8
+                },
+                {
+                    "categoryName": "Sports Drinks",
+                    "discountPercentage": 22
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Steal of a Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 29
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Organic Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "White Wine",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Sparkling Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 17
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 23
+                }
+            ]
+        }
+    ]
+}
+```
+
+The `storeFeatures` field is a bitmask integer representing various store capabilities. Each bit corresponds to a feature:
+
+| Bit | Value | Feature                 |
+|-----|-------|--------------------------|
+| 0   | 1     | In-Store Pickup          |
+| 1   | 2     | Parking                  |
+| 2   | 4     | Wheelchair Access        |
+| 3   | 8     | Open 24 Hours            |
+| 4   | 16    | Pet-Friendly             |
+| 5   | 32    | Free Wi-Fi               |
+| 6   | 64    | Restrooms                |
+| 7   | 128   | Home Delivery            |
+
+### Example 1: Find stores that are not open 24 hours and do not allow pets
+
+This query retrieves stores that are NOT open 24 hours AND do NOT allow pets (bits 3 and 4)
+
+```javascript
+db.stores.find({
+    storeFeatures: {
+        $bitsAllClear: [3, 4]
+    }
+}, {
+    _id: 1,
+    name: 1,
+    storeFeatures: 1
+}).limit(5)
+```
+
+Equivalent:
+
+```javascript
+db.stores.find({
+        storeFeatures: {
+            $bitsAnySet: 24
+        }
+    }, // 8 + 16
+    {
+        _id: 1,
+        name: 1,
+        storeFeatures: 1
+    }).limit(5)
+```
+
+The first five results returned by this query are:
+
+```json
+[
+  {
+    "_id": "a715ab0f-4c6e-4e9d-a812-f2fab11ce0b6",
+    "name": "Lakeshore Retail | Holiday Supply Hub - Marvinfort",
+    "storeFeatures": 38
+  },
+  {
+    "_id": "94792a4c-4b03-466b-91f6-821c4a8b2aa4",
+    "name": "Fourth Coffee | Eyewear Shop - Lessiemouth",
+    "storeFeatures": 225
+  },
+  {
+    "_id": "1a2c387b-bb43-4b14-a6cd-cc05a5dbfbd5",
+    "name": "Contoso, Ltd. | Smart Home Device Vault - Port Katarina",
+    "storeFeatures": 36
+  },
+  {
+    "_id": "e88f0096-4299-4944-9788-695c40786d97",
+    "name": "Adatum Corporation | Handbag Shoppe - Lucienneberg",
+    "storeFeatures": 135
+  },
+  {
+    "_id": "bfb213fa-8db8-419f-8e5b-e7096120bad2",
+    "name": "First Up Consultants | Beauty Product Shop - Hansenton",
+    "storeFeatures": 135
+  }
+]
+```

--- a/api-reference/operators/bitwise-query/$bitsAllSet.md
+++ b/api-reference/operators/bitwise-query/$bitsAllSet.md
@@ -1,0 +1,214 @@
+---
+title: $bitsAllSet
+description: The bitsAllSet command is used to match documents where all the specified bit positions are set.
+type: operators
+category: bitwise-query
+---
+
+# $bitsAllSet
+
+The `$bitsAllSet` operator is used to match documents where all the specified bit positions are set (that is, are 1). This operator is useful for performing bitwise operations on fields that store integer values. It can be used in scenarios where you need to filter documents based on specific bits being set within an integer field.
+
+## Syntax
+
+```javascript
+{
+  <field>: { $bitsAllSet: <bitmask> }
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`field`** | The field in the document on which the bitwise operation is to be performed.|
+| **`<bitmask>`** | A bitmask indicating which bits must be set in the field's value.|
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "location": {
+        "lat": -89.2384,
+        "lon": -46.4012
+    },
+    "staff": {
+        "totalStaff": {
+            "fullTime": 8,
+            "partTime": 20
+        }
+    },
+    "sales": {
+        "totalSales": 75670,
+        "salesByCategory": [
+            {
+                "categoryName": "Wine Accessories",
+                "totalSales": 34440
+            },
+            {
+                "categoryName": "Bitters",
+                "totalSales": 39496
+            },
+            {
+                "categoryName": "Rum",
+                "totalSales": 1734
+            }
+        ]
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Unbeatable Bargain Bash",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 7
+                },
+                {
+                    "categoryName": "Bitters",
+                    "discountPercentage": 15
+                },
+                {
+                    "categoryName": "Brandy",
+                    "discountPercentage": 8
+                },
+                {
+                    "categoryName": "Sports Drinks",
+                    "discountPercentage": 22
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Steal of a Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 29
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Organic Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "White Wine",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Sparkling Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 17
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 23
+                }
+            ]
+        }
+    ]
+}
+```
+
+The `storeFeatures` field is a bitmask integer representing various store capabilities. Each bit corresponds to a feature:
+
+| Bit | Value | Feature                 |
+|-----|-------|--------------------------|
+| 0   | 1     | In-Store Pickup          |
+| 1   | 2     | Parking                  |
+| 2   | 4     | Wheelchair Access        |
+| 3   | 8     | Open 24 Hours            |
+| 4   | 16    | Pet-Friendly             |
+| 5   | 32    | Free Wi-Fi               |
+| 6   | 64    | Restrooms                |
+| 7   | 128   | Home Delivery            |
+
+### Example 1: Find stores that have parking and restrooms
+
+This query retrieves stores that **have parking AND restrooms** (bits 1 and 6)
+
+```javascript
+db.stores.find({
+    storeFeatures: {
+        $bitsAllSet: [1, 6]
+    }
+}, {
+    _id: 1,
+    name: 1,
+    storeFeatures: 1
+}).limit(5)
+```
+
+Equivalent:
+
+```javascript
+db.stores.find({
+    storeFeatures: {
+        $bitsAllSet: 66
+    }
+}, {
+    _id: 1,
+    name: 1,
+    storeFeatures: 1
+}).limit(5)
+```
+
+The first five results returned by this query are:
+
+```json
+[
+  {
+    "_id": "7e53ca0f-6e24-4177-966c-fe62a11e9af5",
+    "name": "Contoso, Ltd. | Office Supply Deals - South Shana",
+    "storeFeatures": 86
+  },
+  {
+    "_id": "44fdb9b9-df83-4492-8f71-b6ef648aa312",
+    "name": "Fourth Coffee | Storage Solution Gallery - Port Camilla",
+    "storeFeatures": 222
+  },
+  {
+    "_id": "728c068a-638c-40af-9172-8ccfa7dddb49",
+    "name": "Contoso, Ltd. | Book Store - Lake Myron",
+    "storeFeatures": 239
+  },
+  {
+    "_id": "a2b54e5c-36cd-4a73-b547-84e21d91164e",
+    "name": "Contoso, Ltd. | Baby Products Corner - Port Jerrold",
+    "storeFeatures": 126
+  },
+  {
+    "_id": "dda2a7d2-6984-40cc-bbea-4cbfbc06d8a3",
+    "name": "Contoso, Ltd. | Home Improvement Closet - Jaskolskiview",
+    "storeFeatures": 107
+  }
+]
+```

--- a/api-reference/operators/bitwise-query/$bitsAnyClear.md
+++ b/api-reference/operators/bitwise-query/$bitsAnyClear.md
@@ -1,0 +1,215 @@
+---
+title: $bitsAnyClear
+description: The $bitsAnyClear operator matches documents where any of the specified bit positions in a bitmask are clear.
+type: operators
+category: bitwise-query
+---
+
+# $bitsAnyClear
+
+This operator is used to match documents where any of the bit positions specified in a bitmask are clear (that is, 0). It's useful for querying documents with binary data or flags stored as integers. This operator enables efficient querying based on specific bit patterns.
+
+## Syntax
+
+```javascript
+{
+  <field>: { $bitsAnyClear: <bitmask> }
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`field`** | The field in the document to be queried.|
+| **`<bitmask>`** |A bitmask where each bit position represents a position to check if it's clear (0).|
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "location": {
+        "lat": -89.2384,
+        "lon": -46.4012
+    },
+    "staff": {
+        "totalStaff": {
+            "fullTime": 8,
+            "partTime": 20
+        }
+    },
+    "sales": {
+        "totalSales": 75670,
+        "salesByCategory": [
+            {
+                "categoryName": "Wine Accessories",
+                "totalSales": 34440
+            },
+            {
+                "categoryName": "Bitters",
+                "totalSales": 39496
+            },
+            {
+                "categoryName": "Rum",
+                "totalSales": 1734
+            }
+        ]
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Unbeatable Bargain Bash",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 7
+                },
+                {
+                    "categoryName": "Bitters",
+                    "discountPercentage": 15
+                },
+                {
+                    "categoryName": "Brandy",
+                    "discountPercentage": 8
+                },
+                {
+                    "categoryName": "Sports Drinks",
+                    "discountPercentage": 22
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Steal of a Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 29
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Organic Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "White Wine",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Sparkling Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 17
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 23
+                }
+            ]
+        }
+    ]
+}
+```
+
+The `storeFeatures` field is a bitmask integer representing various store capabilities. Each bit corresponds to a feature:
+
+| Bit | Value | Feature                 |
+|-----|-------|--------------------------|
+| 0   | 1     | In-Store Pickup          |
+| 1   | 2     | Parking                  |
+| 2   | 4     | Wheelchair Access        |
+| 3   | 8     | Open 24 Hours            |
+| 4   | 16    | Pet-Friendly             |
+| 5   | 32    | Free Wi-Fi               |
+| 6   | 64    | Restrooms                |
+| 7   | 128   | Home Delivery            |
+
+### Example 1: Find stores that don’t have Wi-Fi or in-store pickup
+
+This query retrieves stores that don’t have either Wi-Fi OR in-store pickup (bits 0 and 5)
+
+```javascript
+db.stores.find({
+    storeFeatures: {
+        $bitsAnyClear: [0, 5]
+    }
+}, {
+    _id: 1,
+    name: 1,
+    storeFeatures: 1
+}).limit(5)
+```
+
+Equivalent:
+
+```javascript
+db.stores.find({
+        storeFeatures: {
+            $bitsAnySet: 33
+        }
+    }, // 1 + 32
+    {
+        _id: 1,
+        name: 1,
+        storeFeatures: 1
+    }).limit(5)
+```
+
+The first five results returned by this query are:
+
+```json
+[
+  {
+    "_id": "a715ab0f-4c6e-4e9d-a812-f2fab11ce0b6",
+    "name": "Lakeshore Retail | Holiday Supply Hub - Marvinfort",
+    "storeFeatures": 38
+  },
+  {
+    "_id": "7e53ca0f-6e24-4177-966c-fe62a11e9af5",
+    "name": "Contoso, Ltd. | Office Supply Deals - South Shana",
+    "storeFeatures": 86
+  },
+  {
+    "_id": "44fdb9b9-df83-4492-8f71-b6ef648aa312",
+    "name": "Fourth Coffee | Storage Solution Gallery - Port Camilla",
+    "storeFeatures": 222
+  },
+  {
+    "_id": "e6410bb3-843d-4fa6-8c70-7472925f6d0a",
+    "name": "Relecloud | Toy Collection - North Jaylan",
+    "storeFeatures": 108
+  },
+  {
+    "_id": "9024d615-eed0-429a-a098-6640207cc2b6",
+    "name": "Adatum Corporation | Paper Product Mart - Lake Coralie",
+    "storeFeatures": 204
+  }
+]
+```

--- a/api-reference/operators/bitwise-query/$bitsAnySet.md
+++ b/api-reference/operators/bitwise-query/$bitsAnySet.md
@@ -1,0 +1,215 @@
+---
+title: $bitsAnySet
+description: The $bitsAnySet operator returns documents where any of the specified bit positions are set to 1.
+type: operators
+category: bitwise-query
+---
+
+# $bitsAnySet
+
+This operator is used to select documents where any of the bit positions specified are set to `1`. It's useful for querying documents with fields that store bitmask values. This operator can be handy when working with fields that represent multiple boolean flags in a single integer.
+
+## Syntax
+
+```javascript
+{
+  <field>: { $bitsAnySet: [ <bit positions> ] }
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`field`** | The field to be queried.|
+| **`<bit positions>`** | An array of bit positions to check if any are set to `1`.|
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "location": {
+        "lat": -89.2384,
+        "lon": -46.4012
+    },
+    "staff": {
+        "totalStaff": {
+            "fullTime": 8,
+            "partTime": 20
+        }
+    },
+    "sales": {
+        "totalSales": 75670,
+        "salesByCategory": [
+            {
+                "categoryName": "Wine Accessories",
+                "totalSales": 34440
+            },
+            {
+                "categoryName": "Bitters",
+                "totalSales": 39496
+            },
+            {
+                "categoryName": "Rum",
+                "totalSales": 1734
+            }
+        ]
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Unbeatable Bargain Bash",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 7
+                },
+                {
+                    "categoryName": "Bitters",
+                    "discountPercentage": 15
+                },
+                {
+                    "categoryName": "Brandy",
+                    "discountPercentage": 8
+                },
+                {
+                    "categoryName": "Sports Drinks",
+                    "discountPercentage": 22
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Steal of a Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 29
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Organic Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "White Wine",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Sparkling Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 17
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 23
+                }
+            ]
+        }
+    ]
+}
+```
+
+The `storeFeatures` field is a bitmask integer representing various store capabilities. Each bit corresponds to a feature:
+
+| Bit | Value | Feature                 |
+|-----|-------|--------------------------|
+| 0   | 1     | In-Store Pickup          |
+| 1   | 2     | Parking                  |
+| 2   | 4     | Wheelchair Access        |
+| 3   | 8     | Open 24 Hours            |
+| 4   | 16    | Pet-Friendly             |
+| 5   | 32    | Free Wi-Fi               |
+| 6   | 64    | Restrooms                |
+| 7   | 128   | Home Delivery            |
+
+### Example 1: Find stores that have in-store pickup or drive-thru
+
+This query retrieves stores that offer either home delivery OR free Wi-Fi (bits 5 and 7)
+
+```javascript
+db.stores.find({
+    storeFeatures: {
+        $bitsAnySet: [5, 7]
+    }
+}, {
+    _id: 1,
+    name: 1,
+    storeFeatures: 1
+}).limit(5)
+```
+
+Equivalent:
+
+```javascript
+db.stores.find({
+        storeFeatures: {
+            $bitsAnySet: 160
+        }
+    }, // 32 + 128
+    {
+        _id: 1,
+        name: 1,
+        storeFeatures: 1
+    }).limit(5)
+```
+
+The first five results returned by this query are:
+
+```json
+[
+  {
+    "_id": "a715ab0f-4c6e-4e9d-a812-f2fab11ce0b6",
+    "name": "Lakeshore Retail | Holiday Supply Hub - Marvinfort",
+    "storeFeatures": 38
+  },
+  {
+    "_id": "44fdb9b9-df83-4492-8f71-b6ef648aa312",
+    "name": "Fourth Coffee | Storage Solution Gallery - Port Camilla",
+    "storeFeatures": 222
+  },
+  {
+    "_id": "94792a4c-4b03-466b-91f6-821c4a8b2aa4",
+    "name": "Fourth Coffee | Eyewear Shop - Lessiemouth",
+    "storeFeatures": 225
+  },
+  {
+    "_id": "728c068a-638c-40af-9172-8ccfa7dddb49",
+    "name": "Contoso, Ltd. | Book Store - Lake Myron",
+    "storeFeatures": 239
+  },
+  {
+    "_id": "e6410bb3-843d-4fa6-8c70-7472925f6d0a",
+    "name": "Relecloud | Toy Collection - North Jaylan",
+    "storeFeatures": 108
+  }
+]
+```


### PR DESCRIPTION
Adds the API reference documentation for `bitwise-query`. Includes the following files:

- `api-reference/operators/bitwise-query/$bitsAllClear.md`
- `api-reference/operators/bitwise-query/$bitsAllSet.md`
- `api-reference/operators/bitwise-query/$bitsAnyClear.md`
- `api-reference/operators/bitwise-query/$bitsAnySet.md`
- `api-reference/operators/bitwise-query/index.md`

---

Depends on #4
