### PR TITLE
Add API reference documentation for data-size

### DIFF
--- a/api-reference/operators/data-size/$binarysize.md
+++ b/api-reference/operators/data-size/$binarysize.md
@@ -1,0 +1,179 @@
+---
+title: $binarySize
+description: The $binarySize operator is used to return the size of a binary data field.
+type: operators
+category: data-size
+---
+
+# $binarySize
+
+The `$binarySize` operator is used to return the size of a binary data field. This can be useful when dealing with binary data stored, such as images, files, or any other binary content. The argument for `$binarySize` should be a string, or a binary value.
+
+## Syntax
+
+```javascript
+{
+  $binarySize: "<field>"
+}
+```
+
+### Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`<field>`**| The field for which you want to get the binary size.|
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "location": {
+        "lat": -89.2384,
+        "lon": -46.4012
+    },
+    "staff": {
+        "totalStaff": {
+            "fullTime": 8,
+            "partTime": 20
+        }
+    },
+    "sales": {
+        "totalSales": 75670,
+        "salesByCategory": [
+            {
+                "categoryName": "Wine Accessories",
+                "totalSales": 34440
+            },
+            {
+                "categoryName": "Bitters",
+                "totalSales": 39496
+            },
+            {
+                "categoryName": "Rum",
+                "totalSales": 1734
+            }
+        ]
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Unbeatable Bargain Bash",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 7
+                },
+                {
+                    "categoryName": "Bitters",
+                    "discountPercentage": 15
+                },
+                {
+                    "categoryName": "Brandy",
+                    "discountPercentage": 8
+                },
+                {
+                    "categoryName": "Sports Drinks",
+                    "discountPercentage": 22
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Steal of a Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 29
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Organic Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "White Wine",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Sparkling Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 17
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 23
+                }
+            ]
+        }
+    ]
+}
+```
+
+### Example 1: Calculate the size of a string or binary data in bytes using $binarySize
+
+This query calculates the binary size of the name field for each document in the stores collection.
+
+```javascript
+db.stores.aggregate([
+  {
+    $project: {
+      name: 1,          
+      dataSize: {
+        $binarySize: "$name" // Calculate the binary size of the string data
+      }
+    }
+  },
+  // Limit the result to the first 3 documents
+  { $limit: 3 }  
+])
+```
+
+The first three results returned by this query are:
+
+```json
+[
+  {
+    "_id": "7e53ca0f-6e24-4177-966c-fe62a11e9af5",
+    "name": "Contoso, Ltd. | Office Supply Deals - South Shana",
+    "dataSize": 49
+  },
+  {
+    "_id": "923d2228-6a28-4856-ac9d-77c39eaf1800",
+    "name": "Lakeshore Retail | Home Decor Hub - Franciscoton",
+    "dataSize": 48
+  },
+  {
+    "_id": "a715ab0f-4c6e-4e9d-a812-f2fab11ce0b6",
+    "name": "Lakeshore Retail | Holiday Supply Hub - Marvinfort",
+    "dataSize": 50
+  }
+]
+```

--- a/api-reference/operators/data-size/$bsonsize.md
+++ b/api-reference/operators/data-size/$bsonsize.md
@@ -1,0 +1,180 @@
+---
+title: $bsonSize
+description: The $bsonSize operator returns the size of a document in bytes when encoded as BSON.
+type: operators
+category: data-size
+---
+
+# $bsonSize
+
+The `$bsonSize` operator is used to return the size of a document in bytes when encoded as BSON. It's useful for understanding the storage requirements of documents within your collections. The operator can be used within aggregation pipelines to calculate the size of documents and is helpful for optimizing storage and understanding performance implications.
+
+## Syntax
+
+```javascript
+{
+  $bsonSize: <expression>
+}
+```
+
+### Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`<expression>`**| Any valid expression that resolves to a document whose BSON size you want to calculate.|
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "location": {
+        "lat": -89.2384,
+        "lon": -46.4012
+    },
+    "staff": {
+        "totalStaff": {
+            "fullTime": 8,
+            "partTime": 20
+        }
+    },
+    "sales": {
+        "totalSales": 75670,
+        "salesByCategory": [
+            {
+                "categoryName": "Wine Accessories",
+                "totalSales": 34440
+            },
+            {
+                "categoryName": "Bitters",
+                "totalSales": 39496
+            },
+            {
+                "categoryName": "Rum",
+                "totalSales": 1734
+            }
+        ]
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Unbeatable Bargain Bash",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 7
+                },
+                {
+                    "categoryName": "Bitters",
+                    "discountPercentage": 15
+                },
+                {
+                    "categoryName": "Brandy",
+                    "discountPercentage": 8
+                },
+                {
+                    "categoryName": "Sports Drinks",
+                    "discountPercentage": 22
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Steal of a Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 29
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Organic Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "White Wine",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Sparkling Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 17
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 23
+                }
+            ]
+        }
+    ]
+}
+```
+
+### Example 1: Calculate the total BSON-encoded size of a document in bytes using $bsonSize
+
+This query calculates the BSON size of the document.
+
+```javascript
+db.stores.aggregate([
+  {
+    $project: {
+      _id: 1,              
+      name: 1,         
+      documentSize: { 
+        $bsonSize: "$$ROOT"    //pass the whole document
+      }
+    }
+  },
+  // Limit the result to the first 3 documents
+  { $limit: 3 }  
+])
+```
+
+The first three results returned by this query are:
+
+```json
+[
+  {
+    "_id": "a715ab0f-4c6e-4e9d-a812-f2fab11ce0b6",
+    "name": "Lakeshore Retail | Holiday Supply Hub - Marvinfort",
+    "documentSize": 2226
+  },
+  {
+    "_id": "923d2228-6a28-4856-ac9d-77c39eaf1800",
+    "name": "Lakeshore Retail | Home Decor Hub - Franciscoton",
+    "documentSize": 1365
+  },
+  {
+    "_id": "7e53ca0f-6e24-4177-966c-fe62a11e9af5",
+    "name": "Contoso, Ltd. | Office Supply Deals - South Shana",
+    "documentSize": 1882
+  }
+]
+```


### PR DESCRIPTION
Adds the API reference documentation for `data-size`. Includes the following files:

- `api-reference/operators/data-size/$binarysize.md`
- `api-reference/operators/data-size/$bsonsize.md`
- `api-reference/operators/data-size/index.md`

---

Depends on #4
