### PR TITLE
Add API reference documentation for set-expression

### DIFF
--- a/api-reference/operators/set-expression/$allelementstrue.md
+++ b/api-reference/operators/set-expression/$allelementstrue.md
@@ -1,0 +1,175 @@
+---
+title: $allElementsTrue
+description: The $allElementsTrue operator returns true if all elements in an array evaluate to true.
+type: operators
+category: set-expression
+---
+
+# $allElementsTrue
+
+The `$allElementsTrue` operator evaluates an array as a set. It returns `true` if no element in the array has a value of `false` or equivalent to `false` (like `null`, `0`, or `undefined`). If any element evaluates to a value of `false` or the equivalent, the operator returns `false`.
+
+## Syntax
+
+```javascript
+{
+  $allElementsTrue: [ <array> ]
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| `array` | An array of expressions to evaluate. If the array is empty, `$allElementsTrue` returns `true`. |
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "location": {
+        "lat": -89.2384,
+        "lon": -46.4012
+    },
+    "staff": {
+        "totalStaff": {
+            "fullTime": 8,
+            "partTime": 20
+        }
+    },
+    "sales": {
+        "totalSales": 75670,
+        "salesByCategory": [
+            {
+                "categoryName": "Wine Accessories",
+                "totalSales": 34440
+            },
+            {
+                "categoryName": "Bitters",
+                "totalSales": 39496
+            },
+            {
+                "categoryName": "Rum",
+                "totalSales": 1734
+            }
+        ]
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Unbeatable Bargain Bash",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 7
+                },
+                {
+                    "categoryName": "Bitters",
+                    "discountPercentage": 15
+                },
+                {
+                    "categoryName": "Brandy",
+                    "discountPercentage": 8
+                },
+                {
+                    "categoryName": "Sports Drinks",
+                    "discountPercentage": 22
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Steal of a Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 29
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Organic Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "White Wine",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Sparkling Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 17
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 23
+                }
+            ]
+        }
+    ]
+}
+```
+
+### Example 1: Determine if all the discount percentages are higher than zero
+
+This query determines if all the discount percentages in each promotion event are greater than zero.
+
+```javascript
+db.stores.aggregate([
+  { $match: {"_id": "2cf3f885-9962-4b67-a172-aa9039e9ae2f"} },
+  { $unwind: "$promotionEvents" },
+  {
+    $project: {
+      allDiscountsValid: {
+        $allElementsTrue: [
+          {
+            $map: {
+              input: "$promotionEvents.discounts.discountPercentage",
+              as: "discount",
+              in: { $gt: ["$$discount", 0] }
+            }
+          }
+        ]
+      }
+    }
+  }
+])
+```
+
+This query returns the following result.
+
+```json
+[
+  {
+    "_id": "2cf3f885-9962-4b67-a172-aa9039e9ae2f",
+    "allDiscountsValid": true
+  }
+]
+```

--- a/api-reference/operators/set-expression/$anyelementtrue.md
+++ b/api-reference/operators/set-expression/$anyelementtrue.md
@@ -1,0 +1,254 @@
+---
+title: $anyElementTrue
+description: The $anyElementTrue operator returns true if any element in an array evaluates to a value of true.
+type: operators
+category: set-expression
+---
+
+# $anyElementTrue
+
+The `$anyElementTrue` operator evaluates an array as a set and returns `true` if any element in the array is `true` (or equivalent to `true`). If all the elements evaluate to a value of `false`, `null`, `0`, or `undefined`, the operator returns `false`.
+
+## Syntax
+
+```javascript
+{
+  $anyElementTrue: [ <array> ]
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| `array` | An array of expressions to evaluate. If the array is empty, `$anyElementTrue` returns `false`. |
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "location": {
+        "lat": -89.2384,
+        "lon": -46.4012
+    },
+    "staff": {
+        "totalStaff": {
+            "fullTime": 8,
+            "partTime": 20
+        }
+    },
+    "sales": {
+        "totalSales": 75670,
+        "salesByCategory": [
+            {
+                "categoryName": "Wine Accessories",
+                "totalSales": 34440
+            },
+            {
+                "categoryName": "Bitters",
+                "totalSales": 39496
+            },
+            {
+                "categoryName": "Rum",
+                "totalSales": 1734
+            }
+        ]
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Unbeatable Bargain Bash",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 7
+                },
+                {
+                    "categoryName": "Bitters",
+                    "discountPercentage": 15
+                },
+                {
+                    "categoryName": "Brandy",
+                    "discountPercentage": 8
+                },
+                {
+                    "categoryName": "Sports Drinks",
+                    "discountPercentage": 22
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Steal of a Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 29
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Organic Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "White Wine",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Sparkling Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 17
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 23
+                }
+            ]
+        }
+    ]
+}
+```
+
+### Example 1: Determine if any sales category exceeds a target
+
+This query determines if any sales category exceeds a specified target. In this case, the target is 40,000 in sales.
+
+```javascript
+db.stores.aggregate([
+  { $match: {"_id": "40d6f4d7-50cd-4929-9a07-0a7a133c2e74"} },
+  {
+    $project: {
+      salesByCategory: "$sales.salesByCategory",
+      hasHighPerformingCategory: {
+        $anyElementTrue: [
+          {
+            $map: {
+              input: "$sales.salesByCategory",
+              as: "category",
+              in: { $gt: ["$$category.totalSales", 40000] }
+            }
+          }
+        ]
+      }
+    }
+  }
+])
+```
+
+This query returns the following result.
+
+```json
+[
+  {
+    "_id": "40d6f4d7-50cd-4929-9a07-0a7a133c2e74",
+    "salesByCategory": [
+      {
+        "categoryName": "Sound Bars",
+        "totalSales": 2120,
+        "lastUpdated": "2025-06-11T11:10:34.414Z"
+      },
+      null,
+      {
+        "categoryName": "Game Controllers",
+        "totalSales": 43522
+      },
+      {
+        "categoryName": "Remote Controls",
+        "totalSales": 28946
+      },
+      {
+        "categoryName": "VR Games",
+        "totalSales": 32272
+      }
+    ],
+    "hasHighPerformingCategory": true
+  }
+]
+```
+
+### Example 2: Determine if any promotion event has high discounts
+
+This query determines if any promotion event offers discounts over 20%.
+
+```javascript
+db.stores.aggregate([
+  { $match: {"_id": "40d6f4d7-50cd-4929-9a07-0a7a133c2e74"} },
+  { $unwind: "$promotionEvents" },
+  {
+    $project: {
+      eventName: "$promotionEvents.eventName",
+      hasHighDiscount: {
+        $anyElementTrue: [
+          {
+            $map: {
+              input: "$promotionEvents.discounts",
+              as: "discount",
+              in: { $gte: ["$$discount.discountPercentage", 20] }
+            }
+          }
+        ]
+      }
+    }
+  }
+])
+```
+
+The first five results returned by this query are:
+
+```json
+[
+  {
+    "_id": "40d6f4d7-50cd-4929-9a07-0a7a133c2e74",
+    "eventName": "Massive Markdown Mania",
+    "hasHighDiscount": true
+  },
+  {
+    "_id": "40d6f4d7-50cd-4929-9a07-0a7a133c2e74",
+    "eventName": "Fantastic Deal Days",
+    "hasHighDiscount": true
+  },
+  {
+    "_id": "40d6f4d7-50cd-4929-9a07-0a7a133c2e74",
+    "eventName": "Discount Delight Days",
+    "hasHighDiscount": true
+  },
+  {
+    "_id": "40d6f4d7-50cd-4929-9a07-0a7a133c2e74",
+    "eventName": "Super Sale Spectacular",
+    "hasHighDiscount": true
+  },
+  {
+    "_id": "40d6f4d7-50cd-4929-9a07-0a7a133c2e74",
+    "eventName": "Grand Deal Days",
+    "hasHighDiscount": true
+  }
+]
+```

--- a/api-reference/operators/set-expression/$setdifference.md
+++ b/api-reference/operators/set-expression/$setdifference.md
@@ -1,0 +1,256 @@
+---
+title: $setDifference
+description: The $setDifference operator returns a set with elements that exist in one set but not in a second set.
+type: operators
+category: set-expression
+---
+
+# $setDifference
+
+The `$setDifference` operator returns a set that includes elements that exist in one set but not in another set. It treats arrays as sets and ignores duplicate values and element order.
+
+## Syntax
+
+```javascript
+{
+  $setDifference: [ <array1>, <array2> ]
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| `array1` | The first array to compare. Elements unique to this array are returned. |
+| `array2` | The second array to compare against the first array. Elements that exist in both arrays are excluded from the result. |
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "location": {
+        "lat": -89.2384,
+        "lon": -46.4012
+    },
+    "staff": {
+        "totalStaff": {
+            "fullTime": 8,
+            "partTime": 20
+        }
+    },
+    "sales": {
+        "totalSales": 75670,
+        "salesByCategory": [
+            {
+                "categoryName": "Wine Accessories",
+                "totalSales": 34440
+            },
+            {
+                "categoryName": "Bitters",
+                "totalSales": 39496
+            },
+            {
+                "categoryName": "Rum",
+                "totalSales": 1734
+            }
+        ]
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Unbeatable Bargain Bash",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 7
+                },
+                {
+                    "categoryName": "Bitters",
+                    "discountPercentage": 15
+                },
+                {
+                    "categoryName": "Brandy",
+                    "discountPercentage": 8
+                },
+                {
+                    "categoryName": "Sports Drinks",
+                    "discountPercentage": 22
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Steal of a Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 29
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Organic Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "White Wine",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Sparkling Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 17
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 23
+                }
+            ]
+        }
+    ]
+}
+```
+
+### Example 1: Find categories of products for sale but not discounted
+
+This query retrieves product categories that include sales data but no discounts.
+
+```javascript
+db.stores.aggregate([
+  { $match: {"_id": "40d6f4d7-50cd-4929-9a07-0a7a133c2e74"} },
+  {
+    $project: {
+      name: 1,
+      soldCategories: "$sales.salesByCategory.categoryName",
+      discountedCategories: {
+        $reduce: {
+          input: "$promotionEvents",
+          initialValue: [],
+          in: {
+            $concatArrays: ["$$value", "$$this.discounts.categoryName"]
+          }
+        }
+      }
+    }
+  },
+  {
+    $project: {
+      name: 1,
+      soldCategories: 1,
+      discountedCategories: 1,
+      categoriesWithoutDiscounts: {
+        $setDifference: ["$soldCategories", "$discountedCategories"]
+      }
+    }
+  }
+])
+```
+
+This query returns the following result.
+
+```json
+[
+  {
+    "_id": "40d6f4d7-50cd-4929-9a07-0a7a133c2e74",
+    "name": "Proseware, Inc. | Home Entertainment Hub - East Linwoodbury",
+    "soldCategories": [
+      "Sound Bars",
+      "Game Controllers",
+      "Remote Controls",
+      "VR Games"
+    ],
+    "discountedCategories": [
+      "DVD Players",
+      "Projector Lamps",
+      "Media Players",
+      "Blu-ray Players",
+      "Home Theater Systems",
+      "Televisions"
+    ],
+    "categoriesWithoutDiscounts": [
+      "Sound Bars",
+      "Home Theater Projectors",
+      "Game Controllers",
+      "Remote Controls",
+      "VR Games"
+    ]
+  }
+]
+```
+
+### Example 2: Compare staff distribution types
+
+This query finds the difference between two hypothetical staff requirement lists.
+
+```javascript
+db.stores.aggregate([
+  { $match: {"_id": "40d6f4d7-50cd-4929-9a07-0a7a133c2e74"} },
+  {
+    $project: {
+      name: 1,
+      requiredSkills: ["Sales", "Customer Service", "Technical Support", "Inventory Management"],
+      availableSkills: ["Sales", "Customer Service", "Marketing", "Administration"],
+      missingSkills: {
+        $setDifference: [
+          ["Sales", "Customer Service", "Technical Support", "Inventory Management"],
+          ["Sales", "Customer Service", "Marketing", "Administration"]
+        ]
+      }
+    }
+  }
+])
+```
+
+This query returns the following result.
+
+```json
+[
+  {
+    "_id": "40d6f4d7-50cd-4929-9a07-0a7a133c2e74",
+    "name": "Proseware, Inc. | Home Entertainment Hub - East Linwoodbury",
+    "requiredSkills": [
+      "Sales",
+      "Customer Service", 
+      "Technical Support",
+      "Inventory Management"
+    ],
+    "availableSkills": [
+      "Sales",
+      "Customer Service",
+      "Marketing",
+      "Administration"
+    ],
+    "missingSkills": [
+      "Technical Support",
+      "Inventory Management"
+    ]
+  }
+]
+```

--- a/api-reference/operators/set-expression/$setequals.md
+++ b/api-reference/operators/set-expression/$setequals.md
@@ -1,0 +1,269 @@
+---
+title: $setEquals
+description: The $setEquals operator returns true if two sets have the same distinct elements.
+type: operators
+category: set-expression
+---
+
+# $setEquals
+
+The `$setEquals` operator returns `true` if two sets have the same distinct elements, regardless of order or duplicates. It treats arrays as sets and ignores duplicate values and element order.
+
+## Syntax
+
+```javascript
+{
+  $setEquals: [ <array1>, <array2>, ... ]
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| `array1, array2, ...` | Arrays to compare for equality. You can specify two or more arrays. |
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "location": {
+        "lat": -89.2384,
+        "lon": -46.4012
+    },
+    "staff": {
+        "totalStaff": {
+            "fullTime": 8,
+            "partTime": 20
+        }
+    },
+    "sales": {
+        "totalSales": 75670,
+        "salesByCategory": [
+            {
+                "categoryName": "Wine Accessories",
+                "totalSales": 34440
+            },
+            {
+                "categoryName": "Bitters",
+                "totalSales": 39496
+            },
+            {
+                "categoryName": "Rum",
+                "totalSales": 1734
+            }
+        ]
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Unbeatable Bargain Bash",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 7
+                },
+                {
+                    "categoryName": "Bitters",
+                    "discountPercentage": 15
+                },
+                {
+                    "categoryName": "Brandy",
+                    "discountPercentage": 8
+                },
+                {
+                    "categoryName": "Sports Drinks",
+                    "discountPercentage": 22
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Steal of a Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 29
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Organic Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "White Wine",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Sparkling Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 17
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 23
+                }
+            ]
+        }
+    ]
+}
+```
+
+### Example 1: Compare discount categories between events
+
+This query determines if two promotion events offer discounts on the same categories.
+
+```javascript
+db.stores.aggregate([
+  { $match: {"_id": "26afb024-53c7-4e94-988c-5eede72277d5"} },
+  {
+    $project: {
+      name: 1,
+      event1Categories: { $arrayElemAt: ["$promotionEvents.discounts.categoryName", 0] },
+      event2Categories: { $arrayElemAt: ["$promotionEvents.discounts.categoryName", 1] },
+      sameDiscountCategories: {
+        $setEquals: [
+          { $arrayElemAt: ["$promotionEvents.discounts.categoryName", 0] },
+          { $arrayElemAt: ["$promotionEvents.discounts.categoryName", 1] }
+        ]
+      }
+    }
+  }
+])
+```
+
+This query returns the following result.
+
+```json
+[
+  {
+    "_id": "26afb024-53c7-4e94-988c-5eede72277d5",
+    "name": "First Up Consultants | Microphone Bazaar - South Lexusland",
+    "event1Categories": [
+      "Condenser Microphones",
+      "Dynamic Microphones"
+    ],
+    "event2Categories": [
+      "Streaming Microphones",
+      "Microphone Stands"
+    ],
+    "sameDiscountCategories": false
+  }
+]
+```
+
+### Example 2: Compare staff requirements
+
+This query determines if two stores have the same staff structure requirements.
+
+```javascript
+db.stores.aggregate([
+  { $match: {"_id": { $in: ["26afb024-53c7-4e94-988c-5eede72277d5", "f2a8c190-28e4-4e14-9d8b-0256e53dca66"] }} },
+  {
+    $group: {
+      _id: null,
+      stores: { $push: { _id: "$_id", name: "$name" }}
+    }
+  },
+  {
+    $project: {
+      store1: { $arrayElemAt: ["$stores", 0] },
+      store2: { $arrayElemAt: ["$stores", 1] },
+      staffTypes1: ["fullTime", "partTime"],
+      staffTypes2: ["fullTime", "partTime"],
+      sameStaffStructure: {
+        $setEquals: [
+          ["fullTime", "partTime"],
+          ["fullTime", "partTime"]
+        ]
+      }
+    }
+  }
+])
+```
+
+This query returns the following result.
+
+```json
+[
+  {
+    "_id": null,
+    "store1": {
+      "_id": "26afb024-53c7-4e94-988c-5eede72277d5",
+      "name": "First Up Consultants | Microphone Bazaar - South Lexusland"
+    },
+    "store2": {
+      "_id": "f2a8c190-28e4-4e14-9d8b-0256e53dca66",
+      "name": "Fabrikam, Inc. | Car Accessory Outlet - West Adele"
+    },
+    "staffTypes1": ["fullTime", "partTime"],
+    "staffTypes2": ["fullTime", "partTime"],
+    "sameStaffStructure": true
+  }
+]
+```
+
+### Example 3: Compare sets with duplicates
+
+This query uses the `$setEquals` operator to ignore duplicates and order.
+
+```javascript
+db.stores.aggregate([
+  { $match: {"_id": "26afb024-53c7-4e94-988c-5eede72277d5"} },
+  {
+    $project: {
+      name: 1,
+      array1: ["Microphones", "Stands", "Microphones", "Accessories"],
+      array2: ["Stands", "Accessories", "Microphones"],
+      arraysEqual: {
+        $setEquals: [
+          ["Microphones", "Stands", "Microphones", "Accessories"],
+          ["Stands", "Accessories", "Microphones"]
+        ]
+      }
+    }
+  }
+])
+```
+
+This query returns the following result.
+
+```json
+[
+  {
+    "_id": "26afb024-53c7-4e94-988c-5eede72277d5",
+    "name": "First Up Consultants | Microphone Bazaar - South Lexusland",
+    "array1": ["Microphones", "Stands", "Microphones", "Accessories"],
+    "array2": ["Stands", "Accessories", "Microphones"],
+    "arraysEqual": true
+  }
+]
+```

--- a/api-reference/operators/set-expression/$setintersection.md
+++ b/api-reference/operators/set-expression/$setintersection.md
@@ -1,0 +1,253 @@
+---
+title: $setIntersection
+description: The $setIntersection operator returns the common elements that appear in all input arrays.
+type: operators
+category: set-expression
+---
+
+# $setIntersection
+
+The `$setIntersection` operator returns an array that contains elements that appear in all of the input arrays. It treats arrays as sets, which means that it removes duplicates and ignores the order of elements.
+
+## Syntax
+
+```javascript
+{
+  $setIntersection: [ <array1>, <array2>, ... ]
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| `<array1>, <array2>, ...` | Two or more arrays to find the intersection of. Each array is treated as a set. |
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+  "_id": "40d6f4d7-50cd-4929-9a07-0a7a133c2e74",
+  "name": "Proseware, Inc. | Home Entertainment Hub - East Linwoodbury",
+  "location": {
+    "lat": 70.1272,
+    "lon": 69.7296
+  },
+  "staff": {
+    "totalStaff": {
+      "fullTime": 19,
+      "partTime": 20
+    }
+  },
+  "sales": {
+    "totalSales": 151864,
+    "salesByCategory": [
+      {
+        "categoryName": "Sound Bars",
+        "totalSales": 2120
+      },
+      {
+        "categoryName": "Home Theater Projectors",
+        "totalSales": 45004
+      },
+      {
+        "categoryName": "Game Controllers",
+        "totalSales": 43522
+      },
+      {
+        "categoryName": "Remote Controls",
+        "totalSales": 28946
+      },
+      {
+        "categoryName": "VR Games",
+        "totalSales": 32272
+      }
+    ]
+  },
+  "promotionEvents": [
+    {
+      "eventName": "Massive Markdown Mania",
+      "promotionalDates": {
+        "startDate": {
+          "Year": 2023,
+          "Month": 6,
+          "Day": 29
+        },
+        "endDate": {
+          "Year": 2023,
+          "Month": 7,
+          "Day": 9
+        }
+      },
+      "discounts": [
+        {
+          "categoryName": "DVD Players",
+          "discountPercentage": 14
+        },
+        {
+          "categoryName": "Projector Lamps",
+          "discountPercentage": 6
+        },
+        {
+          "categoryName": "Media Players",
+          "discountPercentage": 21
+        },
+        {
+          "categoryName": "Blu-ray Players",
+          "discountPercentage": 21
+        },
+        {
+          "categoryName": "Home Theater Systems",
+          "discountPercentage": 5
+        },
+        {
+          "categoryName": "Televisions",
+          "discountPercentage": 22
+        }
+      ]
+    },
+    {
+      "eventName": "Discount Delight Days",
+      "promotionalDates": {
+        "startDate": {
+          "Year": 2023,
+          "Month": 12,
+          "Day": 26
+        },
+        "endDate": {
+          "Year": 2024,
+          "Month": 1,
+          "Day": 5
+        }
+      },
+      "discounts": [
+        {
+          "categoryName": "Game Controllers",
+          "discountPercentage": 22
+        },
+        {
+          "categoryName": "Home Theater Projectors",
+          "discountPercentage": 23
+        },
+        {
+          "categoryName": "Sound Bars",
+          "discountPercentage": 10
+        },
+        {
+          "categoryName": "Media Players",
+          "discountPercentage": 10
+        },
+        {
+          "categoryName": "Televisions",
+          "discountPercentage": 9
+        },
+        {
+          "categoryName": "Projector Lamps",
+          "discountPercentage": 24
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Example 1: Find common categories between sales and promotions
+
+This query determines which product categories appear in a store's sales data and promotion discounts.
+
+```javascript
+db.stores.aggregate([
+  { $match: {"_id": "40d6f4d7-50cd-4929-9a07-0a7a133c2e74"} },
+  {
+    $project: {
+      name: 1,
+      salesCategories: "$sales.salesByCategory.categoryName",
+      firstPromotionCategories: { $arrayElemAt: ["$promotionEvents.discounts.categoryName", 0] },
+      secondPromotionCategories: { $arrayElemAt: ["$promotionEvents.discounts.categoryName", 1] },
+      commonSalesAndFirstPromotion: {
+        $setIntersection: [
+          "$sales.salesByCategory.categoryName",
+          { $arrayElemAt: ["$promotionEvents.discounts.categoryName", 0] }
+        ]
+      },
+      commonSalesAndSecondPromotion: {
+        $setIntersection: [
+          "$sales.salesByCategory.categoryName",
+          { $arrayElemAt: ["$promotionEvents.discounts.categoryName", 1] }
+        ]
+      }
+    }
+  }
+])
+```
+
+This query returns the following result.
+
+```json
+[
+  {
+    "_id": "40d6f4d7-50cd-4929-9a07-0a7a133c2e74",
+    "name": "Proseware, Inc. | Home Entertainment Hub - East Linwoodbury",
+    "salesCategories": [
+      "Sound Bars",
+      "Game Controllers",
+      "Remote Controls",
+      "VR Games"
+    ],
+    "firstPromotionCategories": [
+      "DVD Players",
+      "Projector Lamps",
+      "Media Players",
+      "Blu-ray Players",
+      "Home Theater Systems",
+      "Televisions"
+    ],
+    "secondPromotionCategories": [
+      "TV Mounts",
+      "Game Accessories",
+      "Portable Projectors",
+      "Projector Screens",
+      "Blu-ray Players",
+      "DVD Players"
+    ],
+    "commonSalesAndFirstPromotion": [],
+    "commonSalesAndSecondPromotion": []
+  }
+]
+```
+
+### Example 2: Find common categories across multiple promotion events
+
+This query fetches categories that appear in multiple promotion events.
+
+```javascript
+db.stores.aggregate([
+  { $match: {"_id": "40d6f4d7-50cd-4929-9a07-0a7a133c2e74"} },
+  {
+    $project: {
+      name: 1,
+      commonAcrossPromotions: {
+        $setIntersection: [
+          { $arrayElemAt: ["$promotionEvents.discounts.categoryName", 0] },
+          { $arrayElemAt: ["$promotionEvents.discounts.categoryName", 1] },
+          { $arrayElemAt: ["$promotionEvents.discounts.categoryName", 2] }
+        ]
+      }
+    }
+  }
+])
+```
+
+This query returns the following result.
+
+```json
+[
+   {
+      "_id": "40d6f4d7-50cd-4929-9a07-0a7a133c2e74",
+      "name": "Proseware, Inc. | Home Entertainment Hub - East Linwoodbury",
+      "commonAcrossPromotions": []
+   }
+]
+```

--- a/api-reference/operators/set-expression/$setissubset.md
+++ b/api-reference/operators/set-expression/$setissubset.md
@@ -1,0 +1,171 @@
+---
+title: $setIsSubset
+description: The $setIsSubset operator determines if one array is a subset of a second array.
+type: operators
+category: set-expression
+---
+
+# $setIsSubset
+
+The `$setIsSubset` operator returns a Boolean value that indicates if one array is a subset of a second array. It treats arrays as sets, which means it ignores duplicates and element order. It returns `true` if all the elements in the first array exist in the second array. Otherwise, it returns `false`.
+
+## Syntax
+
+```javascript
+{
+  $setIsSubset: [ <array1>, <array2> ]
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| `<array1>` | The array to check to see if it's a subset of `<array2>`. |
+| `<array2>` | The array to check against. |
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+  "_id": "2cf3f885-9962-4b67-a172-aa9039e9ae2f",
+  "name": "First Up Consultants | Bed and Bath Center - South Amir",
+  "location": {
+    "lat": 60.7954,
+    "lon": -142.0012
+  },
+  "staff": {
+    "totalStaff": {
+      "fullTime": 18,
+      "partTime": 17
+    }
+  },
+  "sales": {
+    "totalSales": 37701,
+    "salesByCategory": [
+      {
+        "categoryName": "Mattress Toppers",
+        "totalSales": 37701
+      }
+    ]
+  },
+  "promotionEvents": [
+    {
+      "eventName": "Price Drop Palooza",
+      "promotionalDates": {
+        "startDate": {
+          "Year": 2024,
+          "Month": 9,
+          "Day": 21
+        },
+        "endDate": {
+          "Year": 2024,
+          "Month": 9,
+          "Day": 30
+        }
+      },
+      "discounts": [
+        {
+          "categoryName": "Bath Accessories",
+          "discountPercentage": 18
+        },
+        {
+          "categoryName": "Pillow Top Mattresses",
+          "discountPercentage": 17
+        },
+        {
+          "categoryName": "Bathroom Scales",
+          "discountPercentage": 9
+        },
+        {
+          "categoryName": "Towels",
+          "discountPercentage": 5
+        },
+        {
+          "categoryName": "Bathrobes",
+          "discountPercentage": 5
+        },
+        {
+          "categoryName": "Mattress Toppers",
+          "discountPercentage": 6
+        },
+        {
+          "categoryName": "Hand Towels",
+          "discountPercentage": 9
+        },
+        {
+          "categoryName": "Shower Heads",
+          "discountPercentage": 5
+        },
+        {
+          "categoryName": "Bedspreads",
+          "discountPercentage": 19
+        },
+        {
+          "categoryName": "Bath Mats",
+          "discountPercentage": 21
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Example 1: Determine if sales categories are a subset of promotion categories
+
+This query determines if all of a store's categories are included in their promotion discounts, and vice versa. This query returns categories included under both the sales and promotion brackets. It confirms that the `sales` value is a subset of a particular promotion category (but doesn't do the reverse).
+
+```javascript
+db.stores.aggregate([
+  { $match: {"_id": "2cf3f885-9962-4b67-a172-aa9039e9ae2f"} },
+  {
+    $project: {
+      name: 1,
+      salesCategories: "$sales.salesByCategory.categoryName",
+      promotionCategories: { $arrayElemAt: ["$promotionEvents.discounts.categoryName", 0] },
+      salesAreSubsetOfPromotions: {
+        $setIsSubset: [
+          "$sales.salesByCategory.categoryName",
+          { $arrayElemAt: ["$promotionEvents.discounts.categoryName", 0] }
+        ]
+      },
+      promotionsAreSubsetOfSales: {
+        $setIsSubset: [
+          { $arrayElemAt: ["$promotionEvents.discounts.categoryName", 0] },
+          "$sales.salesByCategory.categoryName"
+        ]
+      }
+    }
+  }
+])
+```
+
+This query returns the following result.
+
+```json
+[
+  {
+    "_id": "2cf3f885-9962-4b67-a172-aa9039e9ae2f",
+    "name": "First Up Consultants | Bed and Bath Center - South Amir",
+    "salesCategories": [
+      "Mattress Toppers"
+    ],
+    "promotionCategories": [
+      "Bath Accessories",
+      "Pillow Top Mattresses",
+      "Bathroom Scales",
+      "Towels",
+      "Bathrobes",
+      "Mattress Toppers",
+      "Hand Towels",
+      "Shower Heads",
+      "Bedspreads",
+      "Bath Mats"
+    ],
+    "salesAreSubsetOfPromotions": true,
+    "promotionsAreSubsetOfSales": false
+  }
+]
+```

--- a/api-reference/operators/set-expression/$setunion.md
+++ b/api-reference/operators/set-expression/$setunion.md
@@ -1,0 +1,197 @@
+---
+title: $setUnion
+description: The $setUnion operator returns an array that contains all the unique elements from the input arrays.
+type: operators
+category: set-expression
+---
+
+# $setUnion
+
+The `$setUnion` operator returns an array that contains all the unique elements from the input arrays. It treats arrays as sets, removes duplicates, and ignores element order. The result contains each unique element only once, regardless of how many times it appears across the input arrays.
+
+## Syntax
+
+```javascript
+{
+  $setUnion: [ <array1>, <array2>, ... ]
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| `<array1>, <array2>, ...` | Two or more arrays to combine. Each array is treated as a set, and duplicates are removed from the final result. |
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+  "_id": "26afb024-53c7-4e94-988c-5eede72277d5",
+  "name": "First Up Consultants | Microphone Bazaar - South Lexusland",
+  "location": {
+    "lat": -29.1866,
+    "lon": -112.7858
+  },
+  "staff": {
+    "totalStaff": {
+      "fullTime": 14,
+      "partTime": 8
+    }
+  },
+  "sales": {
+    "totalSales": 83865,
+    "salesByCategory": [
+      {
+        "categoryName": "Lavalier Microphones",
+        "totalSales": 44174
+      },
+      {
+        "categoryName": "Wireless Microphones",
+        "totalSales": 39691
+      }
+    ]
+  },
+  "promotionEvents": [
+    {
+      "eventName": "Price Cut Spectacular",
+      "promotionalDates": {
+        "startDate": {
+          "Year": 2023,
+          "Month": 12,
+          "Day": 26
+        },
+        "endDate": {
+          "Year": 2024,
+          "Month": 1,
+          "Day": 5
+        }
+      },
+      "discounts": [
+        {
+          "categoryName": "Condenser Microphones",
+          "discountPercentage": 5
+        },
+        {
+          "categoryName": "Dynamic Microphones",
+          "discountPercentage": 14
+        }
+      ]
+    },
+    {
+      "eventName": "Bargain Bonanza",
+      "promotionalDates": {
+        "startDate": {
+          "Year": 2024,
+          "Month": 3,
+          "Day": 25
+        },
+        "endDate": {
+          "Year": 2024,
+          "Month": 4,
+          "Day": 3
+        }
+      },
+      "discounts": [
+        {
+          "categoryName": "Streaming Microphones",
+          "discountPercentage": 14
+        },
+        {
+          "categoryName": "Microphone Stands",
+          "discountPercentage": 14
+        }
+      ]
+    },
+    {
+      "eventName": "Super Savings Extravaganza",
+      "promotionalDates": {
+        "startDate": {
+          "Year": 2024,
+          "Month": 6,
+          "Day": 23
+        },
+        "endDate": {
+          "Year": 2024,
+          "Month": 6,
+          "Day": 30
+        }
+      },
+      "discounts": [
+        {
+          "categoryName": "Condenser Microphones",
+          "discountPercentage": 7
+        },
+        {
+          "categoryName": "Microphone Stands",
+          "discountPercentage": 5
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Example 1: Combine all product categories
+
+This query retrieves a list of all of a store's unique product categories. The list includes sales and promotion categories.
+
+```javascript
+db.stores.aggregate([
+  { $match: {"_id": "26afb024-53c7-4e94-988c-5eede72277d5"} },
+  {
+    $project: {
+      name: 1,
+      salesCategories: "$sales.salesByCategory.categoryName",
+      firstPromotionCategories: { $arrayElemAt: ["$promotionEvents.discounts.categoryName", 0] },
+      secondPromotionCategories: { $arrayElemAt: ["$promotionEvents.discounts.categoryName", 1] },
+      thirdPromotionCategories: { $arrayElemAt: ["$promotionEvents.discounts.categoryName", 2] },
+      allUniqueCategories: {
+        $setUnion: [
+          "$sales.salesByCategory.categoryName",
+          { $arrayElemAt: ["$promotionEvents.discounts.categoryName", 0] },
+          { $arrayElemAt: ["$promotionEvents.discounts.categoryName", 1] },
+          { $arrayElemAt: ["$promotionEvents.discounts.categoryName", 2] }
+        ]
+      }
+    }
+  }
+])
+```
+
+This query returns the following result.
+
+```json
+[
+  {
+    "_id": "26afb024-53c7-4e94-988c-5eede72277d5",
+    "name": "First Up Consultants | Microphone Bazaar - South Lexusland",
+    "salesCategories": [
+      "Lavalier Microphones",
+      "Wireless Microphones"
+    ],
+    "firstPromotionCategories": [
+      "Condenser Microphones",
+      "Dynamic Microphones"
+    ],
+    "secondPromotionCategories": [
+      "Streaming Microphones",
+      "Microphone Stands"
+    ],
+    "thirdPromotionCategories": [
+      "Condenser Microphones",
+      "Microphone Stands"
+    ],
+    "allUniqueCategories": [
+      "Lavalier Microphones",
+      "Wireless Microphones",
+      "Condenser Microphones",
+      "Dynamic Microphones",
+      "Streaming Microphones",
+      "Microphone Stands"
+    ]
+  }
+]
+```


### PR DESCRIPTION
Adds the API reference documentation for `set-expression`. Includes the following files:

- `api-reference/operators/set-expression/$allelementstrue.md`
- `api-reference/operators/set-expression/$anyelementtrue.md`
- `api-reference/operators/set-expression/$setdifference.md`
- `api-reference/operators/set-expression/$setequals.md`
- `api-reference/operators/set-expression/$setintersection.md`
- `api-reference/operators/set-expression/$setissubset.md`
- `api-reference/operators/set-expression/$setunion.md`

---

Depends on #4
