### PR TITLE
Add API reference documentation for timestamp-expression

### DIFF
--- a/api-reference/operators/timestamp-expression/$tsincrement.md
+++ b/api-reference/operators/timestamp-expression/$tsincrement.md
@@ -1,0 +1,168 @@
+---
+title: $tsIncrement
+description: The $tsIncrement operator extracts the increment portion from a timestamp value.
+type: operators
+category: timestamp-expression
+---
+
+# $tsIncrement
+
+The `$tsIncrement` operator returns the increment value from a timestamp. Timestamps in MongoDB consist of two parts: a time value (in seconds since epoch) and an increment value. This operator extracts the increment portion.
+
+## Syntax
+
+```javascript
+{
+  $tsIncrement: <expression>
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`expression`** | An expression that evaluates to a timestamp. If the expression does not evaluate to a timestamp, `$tsIncrement` returns an error. |
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "location": {
+        "lat": -89.2384,
+        "lon": -46.4012
+    },
+    "staff": {
+        "totalStaff": {
+            "fullTime": 8,
+            "partTime": 20
+        }
+    },
+    "sales": {
+        "totalSales": 75670,
+        "salesByCategory": [
+            {
+                "categoryName": "Wine Accessories",
+                "totalSales": 34440
+            },
+            {
+                "categoryName": "Bitters",
+                "totalSales": 39496
+            },
+            {
+                "categoryName": "Rum",
+                "totalSales": 1734
+            }
+        ]
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Unbeatable Bargain Bash",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 7
+                },
+                {
+                    "categoryName": "Bitters",
+                    "discountPercentage": 15
+                },
+                {
+                    "categoryName": "Brandy",
+                    "discountPercentage": 8
+                },
+                {
+                    "categoryName": "Sports Drinks",
+                    "discountPercentage": 22
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Steal of a Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 29
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Organic Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "White Wine",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Sparkling Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 17
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 23
+                }
+            ]
+        }
+    ]
+}
+```
+
+### Example 1: Extract increment from audit timestamp
+
+Extract the increment value from the last updated timestamp in the audit log.
+
+```javascript
+db.stores.aggregate([
+  { $match: {"_id": "2cf3f885-9962-4b67-a172-aa9039e9ae2f"} },
+  {
+    $project: {
+      name: 1,
+      lastUpdatedIncrement: {
+        $tsIncrement: "$auditLog.lastUpdated"
+      }
+    }
+  }
+])
+```
+
+This query returns the following result.
+
+```json
+[
+  {
+    "_id": "2cf3f885-9962-4b67-a172-aa9039e9ae2f",
+    "name": "First Up Consultants | Bed and Bath Center - South Amir",
+    "lastUpdatedIncrement": Long("5")
+  }
+]
+```

--- a/api-reference/operators/timestamp-expression/$tsincrement.md
+++ b/api-reference/operators/timestamp-expression/$tsincrement.md
@@ -7,7 +7,7 @@ category: timestamp-expression
 
 # $tsIncrement
 
-The `$tsIncrement` operator returns the increment value from a timestamp. Timestamps in MongoDB consist of two parts: a time value (in seconds since epoch) and an increment value. This operator extracts the increment portion.
+The `$tsIncrement` operator returns the increment value from a timestamp.
 
 ## Syntax
 

--- a/api-reference/operators/timestamp-expression/$tssecond.md
+++ b/api-reference/operators/timestamp-expression/$tssecond.md
@@ -1,0 +1,177 @@
+---
+title: $tsSecond
+description: The $tsSecond operator extracts the seconds portion from a timestamp value.
+type: operators
+category: timestamp-expression
+---
+
+# $tsSecond
+
+The `$tsSecond` operator returns the seconds value from a timestamp. Timestamps consist of two parts: a time value (in seconds since epoch) and an increment value. This operator extracts the seconds portion, which represents the time since the Unix epoch (January 1, 1970, 00:00:00 UTC).
+
+## Syntax
+
+```javascript
+{
+  $tsSecond: <expression>
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`expression`** | An expression that evaluates to a timestamp. If the expression does not evaluate to a timestamp, `$tsSecond` returns an error. |
+
+## Examples
+
+Consider this sample document from the stores collection.
+
+```json
+{
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "location": {
+        "lat": -89.2384,
+        "lon": -46.4012
+    },
+    "staff": {
+        "totalStaff": {
+            "fullTime": 8,
+            "partTime": 20
+        }
+    },
+    "sales": {
+        "totalSales": 75670,
+        "salesByCategory": [
+            {
+                "categoryName": "Wine Accessories",
+                "totalSales": 34440
+            },
+            {
+                "categoryName": "Bitters",
+                "totalSales": 39496
+            },
+            {
+                "categoryName": "Rum",
+                "totalSales": 1734
+            }
+        ]
+    },
+    "promotionEvents": [
+        {
+            "eventName": "Unbeatable Bargain Bash",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 6,
+                    "Day": 23
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 7,
+                    "Day": 2
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 7
+                },
+                {
+                    "categoryName": "Bitters",
+                    "discountPercentage": 15
+                },
+                {
+                    "categoryName": "Brandy",
+                    "discountPercentage": 8
+                },
+                {
+                    "categoryName": "Sports Drinks",
+                    "discountPercentage": 22
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 19
+                }
+            ]
+        },
+        {
+            "eventName": "Steal of a Deal Days",
+            "promotionalDates": {
+                "startDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 21
+                },
+                "endDate": {
+                    "Year": 2024,
+                    "Month": 9,
+                    "Day": 29
+                }
+            },
+            "discounts": [
+                {
+                    "categoryName": "Organic Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "White Wine",
+                    "discountPercentage": 20
+                },
+                {
+                    "categoryName": "Sparkling Wine",
+                    "discountPercentage": 19
+                },
+                {
+                    "categoryName": "Whiskey",
+                    "discountPercentage": 17
+                },
+                {
+                    "categoryName": "Vodka",
+                    "discountPercentage": 23
+                }
+            ]
+        }
+    ]
+}
+```
+
+### Example 1: Extract seconds from audit timestamp
+
+This query extracts the seconds value from the last updated timestamp in the audit log.
+
+```javascript
+db.stores.aggregate([
+  { $match: {"_id": "2cf3f885-9962-4b67-a172-aa9039e9ae2f"} },
+  {
+    $project: {
+      name: 1,
+      lastUpdatedSeconds: {
+        $tsSecond: "$lastUpdated"
+      },
+      lastUpdatedDate: {
+        $toDate: {
+          $multiply: [
+            { $tsSecond: "$lastUpdated" },
+            1000
+          ]
+        }
+      }
+    }
+  }
+])
+```
+
+This query returns the following result.
+
+```json
+[
+  {
+    "_id": "2cf3f885-9962-4b67-a172-aa9039e9ae2f",
+    "name": "First Up Consultants | Bed and Bath Center - South Amir",
+    "lastUpdatedSeconds": Long("1640995200"),
+    "lastUpdatedDate": ISODate("2022-01-01T00:00:00.000Z")
+  }
+]
+```


### PR DESCRIPTION
Adds the API reference documentation for `timestamp-expression`. Includes the following files:

- `api-reference/operators/timestamp-expression/$tsincrement.md`
- `api-reference/operators/timestamp-expression/$tssecond.md`

---

Depends on #4
