### PR TITLE
Fix markdown errors

### DIFF
--- a/api-reference/commands/query-and-write/delete.md
+++ b/api-reference/commands/query-and-write/delete.md
@@ -172,5 +172,5 @@ db.stores.deleteMany({"promotionEvents.discounts.discountPercentage": 21}, {"lim
 
 ## Related content
 
-- [insert with DocumentDB](insert)
-- [update with DocumentDB](update)
+- [insert with DocumentDB](insert.md)
+- [update with DocumentDB](update.md)

--- a/api-reference/commands/query-and-write/find.md
+++ b/api-reference/commands/query-and-write/find.md
@@ -345,5 +345,5 @@ One of the documents returned shows the specified array elements projected in th
 
 ## Related content
 
-- [insert with DocumentDB](insert)
-- [update with DocumentDB](update)
+- [insert with DocumentDB](insert.md)
+- [update with DocumentDB](update.md)

--- a/api-reference/commands/query-and-write/getMore.md
+++ b/api-reference/commands/query-and-write/getMore.md
@@ -7,7 +7,7 @@ category: query-and-write
 
 # getMore
 
-The `getMore` command is used to retrieve extra batches of documents from an existing cursor. This command is useful when dealing with large datasets that can't be fetched in a single query due to size limitations. The command allows clients to paginate through the results in manageable chunks with commands that return a cursor. For example, [find](./find) and [aggregate](../aggregation/aggregate), to return subsequent batches of documents currently pointed to by the cursor.
+The `getMore` command is used to retrieve extra batches of documents from an existing cursor. This command is useful when dealing with large datasets that can't be fetched in a single query due to size limitations. The command allows clients to paginate through the results in manageable chunks with commands that return a cursor. For example, [find](./find.md) and [aggregate](../aggregation/aggregate.md), to return subsequent batches of documents currently pointed to by the cursor.
 
 ## Syntax
 

--- a/api-reference/commands/query-and-write/insert.md
+++ b/api-reference/commands/query-and-write/insert.md
@@ -352,5 +352,5 @@ The ordered insert command returns a response confirming the order in which docu
 
 ## Related content
 
-- [update with DocumentDB](update)
-- [find with DocumentDB](find)
+- [update with DocumentDB](update.md)
+- [find with DocumentDB](find.md)

--- a/api-reference/commands/query-and-write/update.md
+++ b/api-reference/commands/query-and-write/update.md
@@ -197,5 +197,5 @@ db.stores.updateOne({"_id": "NonExistentDocId"}, {"$set": {"name": "Lakeshore Re
 
 ## Related content
 
-- [insert with DocumentDB](insert)
-- [delete with DocumentDB](delete)
+- [insert with DocumentDB](insert.md)
+- [delete with DocumentDB](delete.md)

--- a/api-reference/operators/array-update/$positional-filtered.md
+++ b/api-reference/operators/array-update/$positional-filtered.md
@@ -1,6 +1,6 @@
 ---
-title: $[]
-description: The $[] operator is used to update all elements using a specific identifier in an array that match the query condition.
+title: $[identifier]
+description: The $[identifier] operator is used to update all elements using a specific identifier in an array that match the query condition.
 type: operators
 category: array-update
 ---


### PR DESCRIPTION
This pull request makes a series of documentation improvements to the API reference, focusing on correcting internal links and clarifying the `$[identifier]` array update operator. The main changes are grouped into two themes: link corrections for consistency and accuracy, and operator documentation clarification.

**Documentation link corrections:**

* Updated internal documentation links throughout the query-and-write command reference files to use the `.md` file extension for consistency and to ensure proper navigation. This affects references to `insert`, `update`, `find`, and `delete` command documentation. [[1]](diffhunk://#diff-b828c508d5b361ad5245ea27eaf28878a219c3ea5402c3818b6abeb36f7a2afcL175-R176) [[2]](diffhunk://#diff-79d80cfc5c22f628c92443c7cf51dcc6ec4844f38414cd8b0ca1d472a84504c4L348-R349) [[3]](diffhunk://#diff-f6c3e20e285a0e76bb8710b12bf07f9a008009a4ea06320ab24b25e2102ce289L355-R356) [[4]](diffhunk://#diff-b42c71aafbfa9040d4b583cd106ddf8d70ae9f7019a954d9e7b6a1ca51fe8f49L200-R201) [[5]](diffhunk://#diff-293c9ba28184db2a79dfebc5791a8f5e91a1d9b6de68859133eba31bacc2ca2bL10-R10)



**Operator documentation clarification:**

* Clarified the documentation for the `$[identifier]` array update operator by updating the title and description to accurately reflect its usage, replacing the generic `$[]` with the more precise `$[identifier]`.

<img width="615" height="351" alt="image" src="https://github.com/user-attachments/assets/6af29630-5fe5-409b-a42b-21c2401ac86a" />
