### PR TITLE
Clarify title and description for $[identifier] operator

### DIFF
--- a/api-reference/operators/array-update/$positional-filtered.md
+++ b/api-reference/operators/array-update/$positional-filtered.md
@@ -1,6 +1,6 @@
 ---
-title: $[]
-description: The $[] operator is used to update all elements using a specific identifier in an array that match the query condition.
+title: $[identifier]
+description: The $[identifier] operator is used to update all elements using a specific identifier in an array that match the query condition.
 type: operators
 category: array-update
 ---


### PR DESCRIPTION
This pull request clarifies the documentation for the `$[identifier]` array update operator by updating the title and description to accurately reflect its usage, replacing the generic `$[]` with the more precise `$[identifier]`.

The current file has the same `title` as the $positional-all article:

<img width="615" height="351" alt="image" src="https://github.com/user-attachments/assets/6af29630-5fe5-409b-a42b-21c2401ac86a" />


