### PR TITLE
Fix broken website links

### DIFF
--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -57,7 +57,6 @@ Choose the getting started guide that best fits your needs:
 
 ### Quick Start Guides
 - [VS Code Extension Quick Start](https://documentdb.io/docs/getting-started/vscode-quickstart) - Recommended for developers new to DocumentDB
-- [MongoDB Shell Quick Start](mongo-shell-quickstart.md) - Ideal for MongoDB users
 - [VS Code Extension Guide](https://documentdb.io/docs/getting-started/vscode-extension-guide) - Comprehensive guide to the VS Code extension
 
 ### Language-Specific Guides

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -56,23 +56,16 @@ DocumentDB consists of two primary components:
 Choose the getting started guide that best fits your needs:
 
 ### Quick Start Guides
-- [VS Code Extension Quick Start](vscode-quickstart.md) - Recommended for developers new to DocumentDB
+- [VS Code Extension Quick Start](https://documentdb.io/docs/getting-started/vscode-quickstart) - Recommended for developers new to DocumentDB
 - [MongoDB Shell Quick Start](mongo-shell-quickstart.md) - Ideal for MongoDB users
-- [VS Code Extension Guide](vscode-extension-guide.md) - Comprehensive guide to the VS Code extension
-
-### Migration Guides
-- [MongoDB to DocumentDB Migration](mongodb-migration.md) - Migrate from MongoDB to DocumentDB
+- [VS Code Extension Guide](https://documentdb.io/docs/getting-started/vscode-extension-guide) - Comprehensive guide to the VS Code extension
 
 ### Language-Specific Guides
-- [Python Setup Guide](python-setup.md) - Using DocumentDB with Python applications
-- [Node.js Setup Guide](nodejs-setup.md) - Using DocumentDB with Node.js applications
+- [Python Setup Guide](https://documentdb.io/docs/getting-started/python-setup) - Using DocumentDB with Python applications
+- [Node.js Setup Guide](https://documentdb.io/docs/getting-started/nodejs-setup) - Using DocumentDB with Node.js applications
 
 ### Deployment Options
-- [Pre-built Packages](prebuilt-packages.md) - Download and install ready-to-use packages
-- [Multi-cloud with Azure](azure-setup.md) - Deploy on Azure with Cosmos DB integration
-- [Multi-cloud with GCP](gcp-setup.md) - Deploy on Google Cloud Platform
-- [Multi-cloud with AWS DocumentDB](aws-setup.md) - Deploy alongside AWS services
-- [Using with YugabyteDB](yugabyte-setup.md) - Combine with distributed SQL capabilities
+- [Pre-built Packages](https://documentdb.io/docs/getting-started/prebuilt-packages) - Download and install ready-to-use packages
 
 ## Community and Support
 
@@ -88,6 +81,5 @@ Choose the getting started guide that best fits your needs:
 ## Next Steps
 
 After choosing your preferred getting started path:
-- Explore our [API Reference](../api-reference/index.md) for detailed documentation
-- Learn about the [Architecture](../architecture/index.md) for deep technical insights
+- Explore our [API Reference](https://documentdb.io/docs/reference) for detailed documentation
 - Join our community to contribute and get support 

--- a/getting-started/navigation.yml
+++ b/getting-started/navigation.yml
@@ -10,13 +10,3 @@
   link: python-setup.md
 - title: Pre-built Packages
   link: prebuilt-packages.md
-- title: AWS Setup
-  link: aws-setup.md
-- title: Azure Setup
-  link: azure-setup.md
-- title: GCP Setup
-  link: gcp-setup.md
-- title: YugabyteDB Setup
-  link: yugabyte-setup.md
-- title: MongoDB Migration Guide
-  link: mongodb-migration.md

--- a/getting-started/navigation.yml
+++ b/getting-started/navigation.yml
@@ -8,5 +8,7 @@
   link: nodejs-setup.md
 - title: Python Setup Guide
   link: python-setup.md
+- title: Mongo Shell Quick Start
+  link: mongo-shell-quickstart.md
 - title: Pre-built Packages
   link: prebuilt-packages.md

--- a/getting-started/python-setup.md
+++ b/getting-started/python-setup.md
@@ -11,7 +11,7 @@ Learn how to set up and use DocumentDB with Python using the official MongoDB Py
 
 - Python 3.7+
 - pip package manager
-- DocumentDB installed and running (see [Pre-built Packages](prebuilt-packages.md))
+- DocumentDB installed and running (see [Pre-built Packages](https://documentdb.io/docs/getting-started/prebuilt-packages))
 - Docker (if DocumentDB is not set up yet)
 - Git installed (for cloning the repository)
 
@@ -280,6 +280,5 @@ if __name__ == '__main__':
 
 ## Next Steps
 
-- Explore advanced features in the [API Reference](../api-reference/index.md)
-- Learn about indexing strategies in the [Architecture](../architecture/index.md)
+- Explore advanced features in the [API Reference](https://documentdb.io/docs/reference)
 - Check out the [MongoDB Shell Guide](mongo-shell-quickstart.md) for additional query examples 

--- a/getting-started/vscode-extension-guide.md
+++ b/getting-started/vscode-extension-guide.md
@@ -344,7 +344,6 @@ The VS Code extension is particularly useful for migrating from MongoDB to Docum
 
 ## Next Steps
 
-- Explore [MongoDB Migration Guide](mongodb-migration-guide.md) for detailed migration steps
-- Learn about [DocumentDB Features](../postgres-api/index.md) for advanced capabilities
+- Learn about [DocumentDB Features]([../postgres-api/index.md](https://documentdb.io/docs/reference)) for advanced capabilities
 - Join our [Discord community](https://discord.gg/vH7bYu524D) for support and discussions
 - Report issues and contribute on [GitHub](https://github.com/documentdb/documentdb)

--- a/getting-started/vscode-quickstart.md
+++ b/getting-started/vscode-quickstart.md
@@ -95,6 +95,5 @@ Get started with DocumentDB using the Visual Studio Code extension for a seamles
 
 ## Next Steps
 
-- Explore advanced querying capabilities in the [API Reference](../api-reference/index.md)
-- Learn about indexing strategies in the [Architecture](../architecture/index.md) section
-- Connect your application using one of our [Language Guides](python-setup.md) 
+- Explore advanced querying capabilities in the [API Reference](https://documentdb.io/docs/reference)
+- Connect your application using the [Python Setup for DocumentDB]([python-setup.md](https://documentdb.io/docs/getting-started/python-setup)) 

--- a/getting-started/vscode-quickstart.md
+++ b/getting-started/vscode-quickstart.md
@@ -96,4 +96,4 @@ Get started with DocumentDB using the Visual Studio Code extension for a seamles
 ## Next Steps
 
 - Explore advanced querying capabilities in the [API Reference](https://documentdb.io/docs/reference)
-- Connect your application using the [Python Setup for DocumentDB]([python-setup.md](https://documentdb.io/docs/getting-started/python-setup)) 
+- Connect your application using the [Python Setup for DocumentDB](https://documentdb.io/docs/getting-started/python-setup) 


### PR DESCRIPTION
Remove references within the docs folder to other .md files as this breaks the website's references on https://documentdb.io

This is a temporary quick fix until a proper design is put in place to handle both direct links and references.