### PR TITLE
Updated `docker` & `DocumentDB for VS Code` Extension sections

### DIFF
--- a/getting-started/vscode-extension-guide.md
+++ b/getting-started/vscode-extension-guide.md
@@ -75,13 +75,13 @@ Use the command palette:
    > **Note:** We're using port `10260` to avoid conflicts with other local database services. You can use port `27017` (the standard MongoDB port) if you prefer.
 
 2. **Connect to DocumentDB using the VS Code extension:**
-   - Open VS Code and click the DocumentDB icon in the sidebar
-   - Click "Add New Connection"
-   - Select "Connection String" and paste:
-     ```
-     mongodb://admin:password123@localhost:10260/?tls=true&tlsAllowInvalidCertificates=true&authMechanism=SCRAM-SHA-256
-     ```
-   - Click "Enter" when prompted for your username and password
+   - Locate and select the DocumentDB icon in the primary VS Code sidebar on the left-hand side.
+   - Add a new connection to your DocumentDB:
+     - In the DocumentDB Connections area, locate and expand the **DocumentDB Local** node.
+     - Select the **New Local Connection** option.
+     - Confirm the port (default value `10260`), username, password, and choose the **Disable TLS/SSL** option.
+     - **Note:** TLS/SSL can be enabled, but this walkthrough skips those steps for simplicity.
+     - A new DocumentDB Local entry will be added and listed in your DocumentDB Connections area.
 
 ## Core Features
 

--- a/getting-started/vscode-extension-guide.md
+++ b/getting-started/vscode-extension-guide.md
@@ -54,11 +54,22 @@ Use the command palette:
 
 1. **Start a local DocumentDB instance using Docker:**
 
+   **Bash**
+
    ```bash
    docker pull ghcr.io/documentdb/documentdb/documentdb-local:latest
    docker tag ghcr.io/documentdb/documentdb/documentdb-local:latest documentdb
    docker run -dt -p 10260:10260 --name documentdb-container documentdb --username admin --password password123
-   docker image rm -f ghcr.io/documentdb/documentdb/documentdb-local:latest
+   docker image rm -f ghcr.io/documentdb/documentdb/documentdb-local:latest || echo "No existing documentdb image to remove"
+   ```
+
+   **PowerShell**
+
+   ```powershell
+   docker pull ghcr.io/documentdb/documentdb/documentdb-local:latest
+   docker tag ghcr.io/documentdb/documentdb/documentdb-local:latest documentdb
+   docker run -dt -p 10260:10260 --name documentdb-container documentdb --username admin --password password123
+   docker image rm -f ghcr.io/documentdb/documentdb/documentdb-local:latest; if ($LASTEXITCODE -ne 0) { echo "No existing documentdb image to remove" }
    ```
 
    > **Note:** We're using port `10260` to avoid conflicts with other local database services. You can use port `27017` (the standard MongoDB port) if you prefer.

--- a/getting-started/vscode-quickstart.md
+++ b/getting-started/vscode-quickstart.md
@@ -49,13 +49,13 @@ Get started with DocumentDB using the Visual Studio Code extension for a seamles
    > **Port Note:** Port `10260` is used by default in these instructions to avoid conflicts with other local database services. You can use port `27017` (the standard MongoDB port) or any other available port if you prefer. If you do, be sure to update the port number in both your `docker run` command and your connection string accordingly.
 
 2. Connecting to your database
-   - Click the DocumentDB icon in the VS Code sidebar
-   - Click "Add New Connection"
-   - On the navigation bar, click on "Connection String"
-   - Paste your connection string:
-     ```
-     mongodb://<YOUR_USERNAME>:<YOUR_PASSWORD>@localhost:10260/?tls=true&tlsAllowInvalidCertificates=true&authMechanism=SCRAM-SHA-256
-     ```
+   - Locate and select the DocumentDB icon in the primary VS Code sidebar on the left-hand side.
+   - Add a new connection to your DocumentDB:
+     - In the DocumentDB Connections area, locate and expand the **DocumentDB Local** node.
+     - Select the **New Local Connection** option.
+     - Confirm the port (default value `10260`), username, password, and choose the **Disable TLS/SSL** option.
+     - **Note:** TLS/SSL can be enabled, but this walkthrough skips those steps for simplicity.
+     - A new DocumentDB Local entry will be added and listed in your DocumentDB Connections area.
 
 3. Creating your first database and collection
    - Click on the drop-down next to your local connection and select "Create Database..."

--- a/getting-started/vscode-quickstart.md
+++ b/getting-started/vscode-quickstart.md
@@ -25,12 +25,25 @@ Get started with DocumentDB using the Visual Studio Code extension for a seamles
 ## Setting Up Your First Database
 
 1. Creating a new DocumentDB instance
+
+   **Bash**
+
    ```bash
    docker pull ghcr.io/documentdb/documentdb/documentdb-local:latest
    docker tag ghcr.io/documentdb/documentdb/documentdb-local:latest documentdb
    docker run -dt -p 10260:10260 --name documentdb-container documentdb --username <YOUR_USERNAME> --password <YOUR_PASSWORD>
-   docker image rm -f ghcr.io/documentdb/documentdb/documentdb-local:latest
+   docker image rm -f ghcr.io/documentdb/documentdb/documentdb-local:latest || echo "No existing documentdb image to remove"
    ```
+
+   **PowerShell**
+
+   ```powershell
+   docker pull ghcr.io/documentdb/documentdb/documentdb-local:latest
+   docker tag ghcr.io/documentdb/documentdb/documentdb-local:latest documentdb
+   docker run -dt -p 10260:10260 --name documentdb-container documentdb --username <YOUR_USERNAME> --password <YOUR_PASSWORD>
+   docker image rm -f ghcr.io/documentdb/documentdb/documentdb-local:latest; if ($LASTEXITCODE -ne 0) { echo "No existing documentdb image to remove" }
+   ```
+
    > **Note:** During the transition to the Linux Foundation, Docker images may still be hosted on Microsoft's container registry. These will be migrated to the new DocumentDB organization as the transition completes.
    > **Note:** Replace `<YOUR_USERNAME>` and `<YOUR_PASSWORD>` with your desired credentials. You must set these when creating the container for authentication to work.
    > **Port Note:** Port `10260` is used by default in these instructions to avoid conflicts with other local database services. You can use port `27017` (the standard MongoDB port) or any other available port if you prefer. If you do, be sure to update the port number in both your `docker run` command and your connection string accordingly.


### PR DESCRIPTION
The main changes include adding separate Bash and PowerShell instructions for starting a local DocumentDB instance, and clarifying the steps for connecting to DocumentDB from VS Code.

---
_Generated by Copilot:_

**Improvements to setup instructions:**

* Added separate Bash and PowerShell command blocks for starting a local DocumentDB instance, making it easier for users on different platforms to follow along. [[1]](diffhunk://#diff-b84cf3c62d82e65a016d04ab04de01fa9d091f25210747b7904d3e8647ff7281R28-R58) [[2]](diffhunk://#diff-e250e2e0f98fd2c61e247b3ffa21eae563fcee39abce17592234847a4c7fe688R57-R84)
* Enhanced Docker image removal commands to handle cases where the image might not exist, providing a user-friendly message instead of an error. [[1]](diffhunk://#diff-b84cf3c62d82e65a016d04ab04de01fa9d091f25210747b7904d3e8647ff7281R28-R58) [[2]](diffhunk://#diff-e250e2e0f98fd2c61e247b3ffa21eae563fcee39abce17592234847a4c7fe688R57-R84)

**Clarifications to connection steps:**

* Updated the steps for connecting to DocumentDB in VS Code to provide more detailed, step-by-step instructions, including UI navigation and configuration options such as disabling TLS/SSL for simplicity. [[1]](diffhunk://#diff-b84cf3c62d82e65a016d04ab04de01fa9d091f25210747b7904d3e8647ff7281R28-R58) [[2]](diffhunk://#diff-e250e2e0f98fd2c61e247b3ffa21eae563fcee39abce17592234847a4c7fe688R57-R84)
* Added notes to explain the default port usage, authentication requirements, and the option to enable TLS/SSL if desired. [[1]](diffhunk://#diff-b84cf3c62d82e65a016d04ab04de01fa9d091f25210747b7904d3e8647ff7281R28-R58) [[2]](diffhunk://#diff-e250e2e0f98fd2c61e247b3ffa21eae563fcee39abce17592234847a4c7fe688R57-R84)