### PR TITLE
Update pre-built packages documentation for v0.111-0

### DIFF
--- a/getting-started/prebuilt-packages.md
+++ b/getting-started/prebuilt-packages.md
@@ -9,36 +9,36 @@ Download and install DocumentDB using the pre-built packages and container image
 
 ## Latest Release
 
-The current release is [`v0.110-0`](https://github.com/documentdb/documentdb/releases/tag/v0.110-0), published on 2026-04-22.
+The current release is [`v0.111-0`](https://github.com/documentdb/documentdb/releases/tag/v0.111-0), published on 2026-05-11.
 
-Compared to `v0.109-0`, this release is primarily a packaging release. It advances the extension version to `0.110-0`, includes the generated upgrade scripts for supported extensions, and adds a workflow-only fix for gateway image signing verification during release builds.
+This release includes collation support for non-unique ordered indexes, performance improvements for `$group` accumulators (`$first`, `$last`, `$sum`, `$avg`), index-only scan enabled by default, `$db` field support in wire protocol commands, and multiple crash fixes.
 
-> `v0.110-0` publishes Linux packages only. macOS and Windows installers are not part of this release.
+> `v0.111-0` publishes Linux packages only. macOS and Windows installers are not part of this release.
 
 ## Package Matrix
 
 | Package family | Supported distributions | PostgreSQL versions | Architectures | Downloads |
 | --- | --- | --- | --- | --- |
-| DEB | Debian 11, Debian 12, Debian 13, Ubuntu 22.04, Ubuntu 24.04 | 16, 17, 18 | amd64, arm64 | [v0.110-0 release assets](https://github.com/documentdb/documentdb/releases/tag/v0.110-0) |
-| RPM | RHEL 8, RHEL 9 | 16, 17, 18 | x86_64, aarch64 | [v0.110-0 release assets](https://github.com/documentdb/documentdb/releases/tag/v0.110-0) |
+| DEB | Debian 11, Debian 12, Debian 13, Ubuntu 22.04, Ubuntu 24.04 | 16, 17, 18 | amd64, arm64 | [v0.111-0 release assets](https://github.com/documentdb/documentdb/releases/tag/v0.111-0) |
+| RPM | RHEL 8, RHEL 9 | 16, 17, 18 | x86_64, aarch64 | [v0.111-0 release assets](https://github.com/documentdb/documentdb/releases/tag/v0.111-0) |
 
 Choose the asset whose filename matches your Linux distribution, PostgreSQL major version, and CPU architecture. For example:
 
-- `ubuntu24.04-postgresql-17-documentdb_0.110-0_amd64.deb`
-- `rhel9-postgresql17-documentdb-0.110.0-1.el9.x86_64.rpm`
+- `ubuntu24.04-postgresql-17-documentdb_0.111-0_amd64.deb`
+- `rhel9-postgresql17-documentdb-0.111.0-1.el9.x86_64.rpm`
 
 ## Install a DEB Package
 
 ```bash
-curl -LO https://github.com/documentdb/documentdb/releases/download/v0.110-0/ubuntu24.04-postgresql-17-documentdb_0.110-0_amd64.deb
-sudo apt install ./ubuntu24.04-postgresql-17-documentdb_0.110-0_amd64.deb
+curl -LO https://github.com/documentdb/documentdb/releases/download/v0.111-0/ubuntu24.04-postgresql-17-documentdb_0.111-0_amd64.deb
+sudo apt install ./ubuntu24.04-postgresql-17-documentdb_0.111-0_amd64.deb
 ```
 
 ## Install an RPM Package
 
 ```bash
-curl -LO https://github.com/documentdb/documentdb/releases/download/v0.110-0/rhel9-postgresql17-documentdb-0.110.0-1.el9.x86_64.rpm
-sudo dnf install ./rhel9-postgresql17-documentdb-0.110.0-1.el9.x86_64.rpm
+curl -LO https://github.com/documentdb/documentdb/releases/download/v0.111-0/rhel9-postgresql17-documentdb-0.111.0-1.el9.x86_64.rpm
+sudo dnf install ./rhel9-postgresql17-documentdb-0.111.0-1.el9.x86_64.rpm
 ```
 
 ## Docker Images
@@ -60,4 +60,4 @@ docker run -dt -p 10260:10260 --name documentdb-container ghcr.io/documentdb/doc
 >
 > **Port Note:** Port `10260` is used by default in these instructions to avoid conflicts with other local database services. You can use port `27017` (the standard MongoDB port) or any other available port if you prefer. If you do, be sure to update the port number in both your `docker run` command and your connection string accordingly.
 
-> For `v0.110-0`, the GHCR repository resolves the `latest` tag for `documentdb-local`. Use a versioned image tag only if that tag is published in the registry for the release you want to run.
+> For `v0.111-0`, the GHCR repository resolves the `latest` tag for `documentdb-local`. Use a versioned image tag only if that tag is published in the registry for the release you want to run.


### PR DESCRIPTION
## Summary

Updates the pre-built packages page to reflect the v0.111-0 release.

## Changes

- Update current release version from v0.110-0 to v0.111-0
- Update release date to 2026-05-11
- Update release description with v0.111-0 highlights (collation support, group accumulator perf, index-only scan, crash fixes)
- Update all download links, example filenames, and install commands
- Update Docker image note

## Related

- Engine release: https://github.com/documentdb/documentdb/releases/tag/v0.111-0