### PR TITLE
Sync docs with documentdb v0.112-0 upstream

### DIFF
--- a/api-reference/operators/aggregation/$bucketauto.md
+++ b/api-reference/operators/aggregation/$bucketauto.md
@@ -1,0 +1,121 @@
+---
+title: $bucketAuto
+description: The $bucketAuto stage automatically distributes documents into a specified number of buckets based on a grouping expression.
+type: operators
+category: aggregation
+---
+
+# $bucketAuto
+
+The `$bucketAuto` stage categorizes documents into a specified number of buckets, attempting to evenly distribute the documents based on the values of a `groupBy` expression. Unlike [`$bucket`](./%24bucket.md), you do not have to provide boundaries — DocumentDB computes them for you.
+
+Supported since `v0.105-0`.
+
+## Syntax
+
+```javascript
+{
+  $bucketAuto: {
+    groupBy: <expression>,
+    buckets: <number>,
+    output: {
+      <outputField1>: { <accumulator1> },
+      ...
+    },
+    granularity: <granularity-string>
+  }
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`groupBy`** | An expression to group documents by. The expression must resolve to a value that can be compared. |
+| **`buckets`** | A positive 32-bit integer that specifies the number of buckets into which the input documents should be grouped. |
+| **`output`** | Optional. A document that specifies the fields to compute for each bucket. Each field is an accumulator expression such as `$sum`, `$avg`, `$min`, `$max`, `$push`, or `$addToSet`. If omitted, `$bucketAuto` outputs a `count` field by default. |
+| **`granularity`** | Optional. A string that specifies the [preferred number series](https://en.wikipedia.org/wiki/Preferred_number) used to round the bucket boundaries. Supported values: `POWERSOF2`, `1-2-5`, `R5`, `R10`, `R20`, `R40`, `R80`, `E6`, `E12`, `E24`, `E48`, `E96`, `E192`. The `groupBy` values must be numeric and non-negative when `granularity` is used. |
+
+## Behavior
+
+- `$bucketAuto` outputs documents with an `_id` of the form `{ "min": <lower>, "max": <upper> }`, representing the bucket's lower and upper boundary. The upper boundary is exclusive for all buckets except the last, which includes its upper boundary.
+- When the number of distinct `groupBy` values is less than `buckets`, the stage produces fewer buckets than requested.
+- When `granularity` is specified, the computed boundaries are rounded outward to the nearest preferred number.
+
+## Examples
+
+Consider this sample `sales` collection:
+
+```json
+[
+  { "_id": 1, "category": "Books",       "price":   8 },
+  { "_id": 2, "category": "Books",       "price":  12 },
+  { "_id": 3, "category": "Electronics", "price":  45 },
+  { "_id": 4, "category": "Electronics", "price": 230 },
+  { "_id": 5, "category": "Toys",        "price":   3 },
+  { "_id": 6, "category": "Toys",        "price":  18 },
+  { "_id": 7, "category": "Clothing",    "price":  35 },
+  { "_id": 8, "category": "Clothing",    "price":  60 }
+]
+```
+
+### Example 1: Three even price buckets
+
+Group the sales into three buckets that contain roughly the same number of documents, and compute a count and average price per bucket:
+
+```javascript
+db.sales.aggregate([
+  {
+    $bucketAuto: {
+      groupBy: "$price",
+      buckets: 3,
+      output: {
+        count: { $sum: 1 },
+        avgPrice: { $avg: "$price" }
+      }
+    }
+  }
+])
+```
+
+Sample output:
+
+```json
+[
+  { "_id": { "min": 3,  "max": 18  }, "count": 3, "avgPrice": 9.67 },
+  { "_id": { "min": 18, "max": 45  }, "count": 3, "avgPrice": 28.33 },
+  { "_id": { "min": 45, "max": 230 }, "count": 2, "avgPrice": 145 }
+]
+```
+
+### Example 2: Buckets with rounded boundaries via `granularity`
+
+Group prices into four buckets rounded to a power-of-two series:
+
+```javascript
+db.sales.aggregate([
+  {
+    $bucketAuto: {
+      groupBy: "$price",
+      buckets: 4,
+      granularity: "POWERSOF2"
+    }
+  }
+])
+```
+
+Sample output:
+
+```json
+[
+  { "_id": { "min": 2,   "max": 16  }, "count": 3 },
+  { "_id": { "min": 16,  "max": 32  }, "count": 1 },
+  { "_id": { "min": 32,  "max": 64  }, "count": 2 },
+  { "_id": { "min": 64,  "max": 256 }, "count": 2 }
+]
+```
+
+## See Also
+
+- [`$bucket`](./%24bucket.md) — fixed-boundary bucketing.
+- [`$group`](./%24group.md) — generic grouping by an expression.

--- a/documentdb-local/index.md
+++ b/documentdb-local/index.md
@@ -115,4 +115,4 @@ For mongosh info see: https://www.mongodb.com/docs/mongodb-shell/
 
 ## Reporting issues
 
-If you encounter issues with using this version of DoucmenttDB, open an issue in the GitHub repository (<https://github.com/documentdb/documentdb/issues>) and tag it with the label `documentdb-local`.
+If you encounter issues with using this version of DocumentDB, open an issue in the GitHub repository (<https://github.com/documentdb/documentdb/issues>) and tag it with the label `documentdb-local`.

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -11,10 +11,11 @@ DocumentDB is an open-source document database platform built on PostgreSQL. It 
 
 DocumentDB provides a NoSQL datastore implemented using PostgreSQL, giving developers complete visibility into the architecture and implementation of the engine. It's designed to offer:
 
-- Full compatibility with MongoDB wire protocol through the `pg_documentdb_api` layer
+- Full compatibility with the MongoDB wire protocol through the `pg_documentdb_gw` gateway
+- Public document CRUD and management APIs through the `pg_documentdb` extension
 - Native BSON document support via the `pg_documentdb_core` PostgreSQL extension
-- Advanced indexing capabilities including single field, multi-key, compound, text, and geospatial indexes
-- Vector search functionality powered by the `pg_vector` PostgreSQL extension
+- Advanced indexing capabilities including single field, multi-key, compound, text, geospatial, and vector indexes
+- Vector search functionality powered by the `pgvector` PostgreSQL extension
 - Enterprise-grade security with SCRAM authentication
 - Full PostgreSQL compatibility for advanced SQL operations
 
@@ -28,20 +29,25 @@ DocumentDB provides a NoSQL datastore implemented using PostgreSQL, giving devel
 
 ## Architecture Components
 
-DocumentDB consists of two primary components:
+DocumentDB consists of three primary components:
 
-1. **pg_documentdb_core**: A custom PostgreSQL extension that provides:
+1. **pg_documentdb_core**: A PostgreSQL extension that provides:
    - Native BSON data type support in PostgreSQL
    - Field-level indexing at any nesting depth
-   - Multi-key, compound, text, and geospatial indexing
-   - Vector search capabilities for AI/ML applications
-   - SCRAM authentication mechanism
+   - Multi-key, compound, text, and geospatial indexing primitives
+   - Foundational operators and helpers used by the higher layers
 
-2. **pg_documentdb_api**: The data plane implementing:
+2. **pg_documentdb**: The data plane implementing:
    - CRUD operations with MongoDB compatibility
-   - Advanced query functionality
+   - Advanced query and aggregation functionality
    - Index management and optimization
-   - Protocol translation layer for MongoDB wire protocol
+   - User and role management commands
+
+3. **pg_documentdb_gw**: The gateway that:
+   - Implements the MongoDB wire protocol
+   - Terminates TLS and authenticates clients (SCRAM-SHA-256 and Plain)
+   - Translates MongoDB commands into calls against `pg_documentdb`
+   - Manages cursors, sessions, and connection state for MongoDB drivers
 
 ## Common Use Cases
 

--- a/getting-started/mongo-shell-quickstart.md
+++ b/getting-started/mongo-shell-quickstart.md
@@ -1,348 +1,266 @@
 ---
 title: MongoDB Shell Quick Start
-description: Learn how to set up and use DocumentDB with Node.js using the official MongoDB Node.js driver.
+description: Get started with DocumentDB using the MongoDB shell (mongosh) for a familiar MongoDB-compatible experience.
 ---
 
-# Node.js Setup Guide
+# MongoDB Shell Quick Start
 
-Learn how to set up and use DocumentDB with Node.js using the official MongoDB Node.js driver.
+Get started with DocumentDB using the MongoDB shell (`mongosh`) for a familiar MongoDB-compatible experience.
 
 ## Prerequisites
 
-- Node.js 14.x or later
-- npm or yarn package manager
-- DocumentDB installed and running
-- Docker installed (if set up is not completed yet)
-- Basic Node.js knowledge
+- [MongoDB Shell (`mongosh`)](https://www.mongodb.com/try/download/shell) installed
+- [Docker Desktop](https://www.docker.com/) installed and running
+- Basic MongoDB knowledge
 
-## Project Setup (skip if already done)
+## Setting up DocumentDB locally
 
-Before connecting from Node.js, make sure you have a running DocumentDB instance using Docker:
+Pull the latest `documentdb-local` image and start the container. DocumentDB Local listens on port `10260` by default and requires the username and password to be set on first run.
 
-   ```bash
-   # Pull the latest DocumentDB Docker image
-   docker pull ghcr.io/documentdb/documentdb/documentdb-local:latest
+```bash
+# Pull the latest DocumentDB Docker image
+docker pull ghcr.io/documentdb/documentdb/documentdb-local:latest
 
-   # Tag the image for convenience
-   docker tag ghcr.io/documentdb/documentdb/documentdb-local:latest documentdb
+# Tag the image for convenience
+docker tag ghcr.io/documentdb/documentdb/documentdb-local:latest documentdb
 
-   # Run the container with your chosen username and password
-   docker run -dt -p 10260:10260 --name documentdb-container documentdb --username <YOUR_USERNAME> --password <YOUR_PASSWORD>
+# Run the container with your chosen username and password
+docker run -dt -p 10260:10260 --name documentdb-container documentdb --username <YOUR_USERNAME> --password <YOUR_PASSWORD>
+```
 
-   docker image rm -f ghcr.io/documentdb/documentdb/documentdb-local:latest
-  ```
-> **Note:** Replace `<YOUR_USERNAME>` and `<YOUR_PASSWORD>` with your desired credentials. You must set these when creating the container for authentication to work.
+> **Note:** Replace `<YOUR_USERNAME>` and `<YOUR_PASSWORD>` with your desired credentials. These must be set when creating the container for authentication to work.
 >
-> **Port Note:** Port `10260` is used by default in these instructions to avoid conflicts with other local database services. You can use port `27017` (the standard MongoDB port) or any other available port if you prefer. If you do, be sure to update the port number in both your `docker run` command and your connection string accordingly.
+> **Port note:** Port `10260` is used by default to avoid conflicts with other local database services. You can use port `27017` (the standard MongoDB port) or any other available port — update the port in the `docker run` command and your connection string accordingly.
 
-## Installation
+Confirm the container is running:
 
-1. Creating a new Node.js project
-   ```bash
-   mkdir my-documentdb-app
-   cd my-documentdb-app
-   npm init -y
-   ```
-
-2. Installing the MongoDB driver
-   ```bash
-   npm install mongodb
-   ```
+```bash
+docker ps
+```
 
 ## Connecting to DocumentDB
 
-```javascript
-const { MongoClient } = require('mongodb');
+DocumentDB Local terminates TLS on the gateway port. The container generates a new self-signed certificate on each start, so the simplest local connection skips certificate validation with `tlsAllowInvalidCertificates=true`.
 
-const uri = 'mongodb://localhost:27017';
-const client = new MongoClient(uri);
-
-async function connect() {
-  try {
-    await client.connect();
-    const db = client.db('your_database');
-    return db;
-  } catch (error) {
-    console.error('Connection error:', error);
-    throw error;
-  }
-}
+```bash
+mongosh "mongodb://<YOUR_USERNAME>:<YOUR_PASSWORD>@localhost:10260/?tls=true&tlsAllowInvalidCertificates=true"
 ```
+
+For instructions on installing the generated certificate so you can validate it normally, see [DocumentDB Local](https://documentdb.io/docs/documentdb-local).
 
 ## Basic Operations
 
-1. Creating collections
-   ```javascript
-   const collection = db.collection('your_collection');
-   ```
+### Create a database and collection
 
-2. Document operations
+```javascript
+// Switch to (or create) a database
+use mydb
 
-   **Insert operations**
-   ```javascript
-   // Insert a single document
-   const result = await collection.insertOne({ 
-     name: "John Doe", 
-     email: "john@example.com", 
-     created_at: new Date() 
-   });
-   console.log('Inserted document ID:', result.insertedId);
+// Create a collection
+db.createCollection("users")
+```
 
-   // Insert multiple documents
-   const documents = [
-     { name: "Jane Smith", email: "jane@example.com" },
-     { name: "Bob Johnson", email: "bob@example.com" }
-   ];
-   const result = await collection.insertMany(documents);
-   console.log('Inserted document IDs:', result.insertedIds);
-   ```
+### Insert documents
 
-   **Find operations**
-   ```javascript
-   // Find all documents
-   const allUsers = await collection.find({}).toArray();
-   console.log('All users:', allUsers);
+```javascript
+// Insert a single document
+db.users.insertOne({
+  name: "John Doe",
+  email: "john@example.com",
+  created_at: new Date()
+})
 
-   // Find with criteria
-   const user = await collection.findOne({ name: "John Doe" });
-   console.log('Found user:', user);
+// Insert multiple documents
+db.users.insertMany([
+  { name: "Jane Smith", email: "jane@example.com" },
+  { name: "Bob Johnson", email: "bob@example.com" }
+])
+```
 
-   // Find with projection
-   const users = await collection.find({}, { 
-     projection: { name: 1, email: 1, _id: 0 } 
-   }).toArray();
-   console.log('Users with projection:', users);
+### Query documents
 
-   // Complex queries
-   const recentUsers = await collection.find({
-     $and: [
-       { created_at: { $gte: new Date("2025-01-01") } },
-       { email: { $regex: "@example.com$" } }
-     ]
-   }).toArray();
-   console.log('Recent users:', recentUsers);
-   ```
+```javascript
+// Find all documents
+db.users.find()
 
-   **Update operations**
-   ```javascript
-   // Update a single document
-   const result = await collection.updateOne(
-     { name: "John Doe" },
-     { $set: { status: "active" } }
-   );
-   console.log('Modified count:', result.modifiedCount);
+// Find with a filter
+db.users.find({ name: "John Doe" })
 
-   // Update multiple documents
-   const result = await collection.updateMany(
-     { email: { $regex: "@example.com$" } },
-     { $set: { domain: "example.com" } }
-   );
-   console.log('Modified count:', result.modifiedCount);
-   ```
+// Find with a projection
+db.users.find({}, { name: 1, email: 1, _id: 0 })
 
-   **Delete operations**
-   ```javascript
-   // Delete a single document
-   const result = await collection.deleteOne({ name: "John Doe" });
-   console.log('Deleted count:', result.deletedCount);
+// Combine multiple operators
+db.users.find({
+  $and: [
+    { created_at: { $gte: new Date("2026-01-01") } },
+    { email: { $regex: "@example.com$" } }
+  ]
+})
+```
 
-   // Delete multiple documents
-   const result = await collection.deleteMany({ status: "inactive" });
-   console.log('Deleted count:', result.deletedCount);
-   ```
+### Update documents
 
-3. Working with indexes
-   ```javascript
-   // Create a single field index
-   await collection.createIndex({ email: 1 });
-   console.log('Created index on email field');
+```javascript
+// Update a single document
+db.users.updateOne(
+  { name: "John Doe" },
+  { $set: { status: "active" } }
+)
 
-   // Create a compound index
-   await collection.createIndex({ name: 1, email: 1 });
-   console.log('Created compound index on name and email');
+// Update many documents
+db.users.updateMany(
+  { email: { $regex: "@example.com$" } },
+  { $set: { domain: "example.com" } }
+)
+```
 
-   // Create a unique index
-   await collection.createIndex({ email: 1 }, { unique: true });
-   console.log('Created unique index on email');
+### Delete documents
 
-   // Create a text index
-   await collection.createIndex({ content: "text" });
-   console.log('Created text index on content field');
+```javascript
+// Delete a single document
+db.users.deleteOne({ name: "John Doe" })
 
-   // Create a geospatial index
-   await collection.createIndex({ location: "2dsphere" });
-   console.log('Created geospatial index on location field');
+// Delete many documents
+db.users.deleteMany({ status: "inactive" })
+```
 
-   // Create a vector index
-   await collection.createIndex({ 
-     embedding: "vector" 
-   }, { 
-     vectorOptions: { dimensions: 384 } 
-   });
-   console.log('Created vector index on embedding field');
+## Working with Indexes
 
-   // List all indexes
-   const indexes = await collection.indexes();
-   console.log('Collection indexes:', indexes);
-   ```
+DocumentDB supports many MongoDB-compatible index types, including single-field, compound, multi-key, partial, unique, text, geospatial, and vector indexes.
 
-4. Advanced operations
-   ```javascript
-   // Aggregation pipeline
-   const pipeline = [
-     { $match: { status: "completed" } },
-     { $group: {
-         _id: "$customer",
-         total: { $sum: "$amount" },
-         count: { $sum: 1 }
-     }},
-     { $sort: { total: -1 } }
-   ];
-   const results = await collection.aggregate(pipeline).toArray();
-   console.log('Aggregation results:', results);
+```javascript
+// Single field index
+db.users.createIndex({ email: 1 })
 
-   // Vector search operations
-   const vectorQuery = {
-     $vectorSearch: {
-       queryVector: [0.1, 0.2, 0.3],
-       path: "embedding",
-       numCandidates: 100,
-       limit: 10
-     }
-   };
-   const vectorResults = await collection.find(vectorQuery).toArray();
-   console.log('Vector search results:', vectorResults);
+// Compound index
+db.users.createIndex({ name: 1, email: 1 })
 
-   // Geospatial queries
-   const geoQuery = {
-     location: {
-       $near: {
-         $geometry: {
-           type: "Point",
-           coordinates: [-73.9667, 40.78]
-         },
-         $maxDistance: 1000
-       }
-     }
-   };
-   const geoResults = await collection.find(geoQuery).toArray();
-   console.log('Geospatial results:', geoResults);
+// Unique index
+db.users.createIndex({ email: 1 }, { unique: true })
 
-   // Text search
-   const textResults = await collection.find({
-     $text: { $search: "search term" }
-   }).toArray();
-   console.log('Text search results:', textResults);
-   ```
+// Text index
+db.articles.createIndex({ content: "text" })
 
-5. Complete example
-   ```javascript
-   const { MongoClient } = require('mongodb');
+// Geospatial (2dsphere) index
+db.places.createIndex({ location: "2dsphere" })
 
-   async function main() {
-     const uri = 'mongodb://localhost:10260';
-     const client = new MongoClient(uri);
+// Partial index
+db.orders.createIndex(
+  { orderDate: 1 },
+  { partialFilterExpression: { status: "active" } }
+)
+```
 
-     try {
-       await client.connect();
-       console.log('Connected to DocumentDB');
+To create a vector index on an embedding field, use the `cosmosSearchOptions` index spec accepted by the DocumentDB gateway:
 
-       const db = client.db('myapp');
-       const collection = db.collection('users');
+```javascript
+db.products.createIndex(
+  { embedding: "cosmosSearch" },
+  {
+    name: "vectorIndex",
+    cosmosSearchOptions: {
+      kind: "vector-ivf",
+      numLists: 100,
+      similarity: "COS",
+      dimensions: 384
+    }
+  }
+)
+```
 
-       // Create an index
-       await collection.createIndex({ email: 1 }, { unique: true });
+## Aggregation Pipelines
 
-       // Insert documents
-       const insertResult = await collection.insertMany([
-         { name: "John Doe", email: "john@example.com", age: 30 },
-         { name: "Jane Smith", email: "jane@example.com", age: 25 },
-         { name: "Bob Johnson", email: "bob@example.com", age: 35 }
-       ]);
-       console.log('Inserted documents:', insertResult.insertedIds);
+```javascript
+db.orders.aggregate([
+  { $match: { status: "completed" } },
+  { $group: {
+      _id: "$customer",
+      total: { $sum: "$amount" },
+      count: { $sum: 1 }
+  }},
+  { $sort: { total: -1 } }
+])
+```
 
-       // Find documents
-       const users = await collection.find({ age: { $gte: 30 } }).toArray();
-       console.log('Users 30 and older:', users);
+DocumentDB also supports stages such as `$lookup`, `$unwind`, `$facet`, `$bucket`, `$bucketAuto`, and many others. See the [API Reference](https://documentdb.io/docs/api-reference) for the full list.
 
-       // Update a document
-       const updateResult = await collection.updateOne(
-         { email: "john@example.com" },
-         { $set: { status: "active" } }
-       );
-       console.log('Updated document:', updateResult.modifiedCount);
+## Vector Search
 
-       // Aggregate data
-       const stats = await collection.aggregate([
-         { $group: { _id: null, avgAge: { $avg: "$age" }, count: { $sum: 1 } } }
-       ]).toArray();
-       console.log('User statistics:', stats[0]);
+```javascript
+db.products.aggregate([
+  {
+    $search: {
+      cosmosSearch: {
+        vector: [0.1, 0.2, 0.3],
+        path: "embedding",
+        k: 10
+      }
+    }
+  }
+])
+```
 
-     } catch (error) {
-       console.error('Error:', error);
-     } finally {
-       await client.close();
-       console.log('Disconnected from DocumentDB');
-     }
-   }
+## Geospatial Queries
 
-   main().catch(console.error);
-   ```
+```javascript
+db.places.find({
+  location: {
+    $near: {
+      $geometry: { type: "Point", coordinates: [-73.9667, 40.78] },
+      $maxDistance: 1000
+    }
+  }
+})
+```
 
-## Working with Promises and Async/Await
+## Diagnostics and Administration
 
-1. Promise-based operations
-2. Async/await patterns
-3. Error handling
-4. Connection management
+DocumentDB ships with a number of MongoDB-compatible administrative commands:
 
-## Advanced Features
+```javascript
+// Build info and server info
+db.runCommand({ buildInfo: 1 })
+db.runCommand({ hello: 1 })
 
-1. Bulk operations
-2. Aggregation framework
-3. Vector search
-4. Geospatial queries
-5. Change streams
-6. Transactions
+// Database and collection statistics
+db.stats()
+db.users.stats()
 
-## Error Handling
+// List databases (admin DB)
+db.adminCommand({ listDatabases: 1 })
 
-1. Connection errors
-2. Operation errors
-3. Timeout handling
-4. Retry strategies
+// Inspect or kill currently running operations
+db.currentOp()
+db.killOp(<opid>)
+
+// Validate a collection
+db.users.validate()
+
+// Compact a collection
+db.runCommand({ compact: "users" })
+```
+
+User and role management commands are also supported:
+
+```javascript
+// Users
+db.runCommand({ createUser: "alice", pwd: "secret", roles: [ { role: "readWrite", db: "mydb" } ] })
+db.runCommand({ usersInfo: 1 })
+
+// Roles
+db.runCommand({ createRole: "appWriter", privileges: [], roles: [ "readWrite" ] })
+db.runCommand({ rolesInfo: 1 })
+```
 
 ## Best Practices
 
-1. Connection pooling
-2. Query optimization
-3. Bulk operations
-4. Error handling
-5. Security considerations
-
-## Sample Applications
-
-1. Basic CRUD application
-2. REST API with Express
-3. Vector search example
-4. Real-time applications with change streams
-
-## Testing
-
-1. Setting up test environment
-2. Unit testing with Jest/Mocha
-3. Integration testing
-4. Mock testing
-
-## Deployment
-
-1. Development setup
-2. Production considerations
-3. Monitoring and logging
-4. Performance optimization
+- **Connection pooling:** reuse a single `mongosh` connection per session.
+- **Indexes:** create indexes that match your most frequent query and sort patterns. Use `db.collection.getIndexes()` to inspect existing indexes.
+- **Explain plans:** prefix queries with `.explain("executionStats")` to inspect how DocumentDB plans and executes them.
+- **TLS:** in production, always provide the gateway certificate via `--tlsCAFile` rather than disabling validation.
 
 ## Next Steps
 
-- Explore advanced features
-- Learn about indexing strategies
-- Build your first application 
+- Browse the [API Reference](https://documentdb.io/docs/api-reference) for the full list of supported commands, operators, and aggregation stages.
+- Connect from your application using the [Python](https://documentdb.io/docs/getting-started/python-setup) or [Node.js](https://documentdb.io/docs/getting-started/nodejs-setup) setup guides.
+- Use the [Visual Studio Code extension](https://documentdb.io/docs/getting-started/vscode-extension-guide) for a GUI experience over the same gateway.

--- a/getting-started/prebuilt-packages.md
+++ b/getting-started/prebuilt-packages.md
@@ -9,36 +9,36 @@ Download and install DocumentDB using the pre-built packages and container image
 
 ## Latest Release
 
-The current release is [`v0.111-0`](https://github.com/documentdb/documentdb/releases/tag/v0.111-0), published on 2026-05-11.
+The current release is [`v0.112-0`](https://github.com/documentdb/documentdb/releases/tag/v0.112-0), published on 2026-05-26.
 
-This release includes collation support for non-unique ordered indexes, performance improvements for `$group` accumulators (`$first`, `$last`, `$sum`, `$avg`), index-only scan enabled by default, `$db` field support in wire protocol commands, and multiple crash fixes.
+This release eliminates subquery migration for many `$group` aggregations, adds index pushdown for `$group` when `_id` is a multi-field document expression, expands collation support for non-unique ordered indexes (`$lt`/`$lte`/`$ne`/`$not` combinations), migrates streaming query execution off the SPI cursor path, and ships several crash fixes for `BSONFIRSTN`/`BSONLASTN`/`BSONMAXN`/`BSONMINN` on empty sharded collections.
 
-> `v0.111-0` publishes Linux packages only. macOS and Windows installers are not part of this release.
+> `v0.112-0` publishes Linux packages only. macOS and Windows installers are not part of this release.
 
 ## Package Matrix
 
 | Package family | Supported distributions | PostgreSQL versions | Architectures | Downloads |
 | --- | --- | --- | --- | --- |
-| DEB | Debian 11, Debian 12, Debian 13, Ubuntu 22.04, Ubuntu 24.04 | 16, 17, 18 | amd64, arm64 | [v0.111-0 release assets](https://github.com/documentdb/documentdb/releases/tag/v0.111-0) |
-| RPM | RHEL 8, RHEL 9 | 16, 17, 18 | x86_64, aarch64 | [v0.111-0 release assets](https://github.com/documentdb/documentdb/releases/tag/v0.111-0) |
+| DEB | Debian 11, Debian 12, Debian 13, Ubuntu 22.04, Ubuntu 24.04 | 16, 17, 18 | amd64, arm64 | [v0.112-0 release assets](https://github.com/documentdb/documentdb/releases/tag/v0.112-0) |
+| RPM | RHEL 8, RHEL 9 | 16, 17, 18 | x86_64, aarch64 | [v0.112-0 release assets](https://github.com/documentdb/documentdb/releases/tag/v0.112-0) |
 
 Choose the asset whose filename matches your Linux distribution, PostgreSQL major version, and CPU architecture. For example:
 
-- `ubuntu24.04-postgresql-17-documentdb_0.111-0_amd64.deb`
-- `rhel9-postgresql17-documentdb-0.111.0-1.el9.x86_64.rpm`
+- `ubuntu24.04-postgresql-17-documentdb_0.112-0_amd64.deb`
+- `rhel9-postgresql17-documentdb-0.112.0-1.el9.x86_64.rpm`
 
 ## Install a DEB Package
 
 ```bash
-curl -LO https://github.com/documentdb/documentdb/releases/download/v0.111-0/ubuntu24.04-postgresql-17-documentdb_0.111-0_amd64.deb
-sudo apt install ./ubuntu24.04-postgresql-17-documentdb_0.111-0_amd64.deb
+curl -LO https://github.com/documentdb/documentdb/releases/download/v0.112-0/ubuntu24.04-postgresql-17-documentdb_0.112-0_amd64.deb
+sudo apt install ./ubuntu24.04-postgresql-17-documentdb_0.112-0_amd64.deb
 ```
 
 ## Install an RPM Package
 
 ```bash
-curl -LO https://github.com/documentdb/documentdb/releases/download/v0.111-0/rhel9-postgresql17-documentdb-0.111.0-1.el9.x86_64.rpm
-sudo dnf install ./rhel9-postgresql17-documentdb-0.111.0-1.el9.x86_64.rpm
+curl -LO https://github.com/documentdb/documentdb/releases/download/v0.112-0/rhel9-postgresql17-documentdb-0.112.0-1.el9.x86_64.rpm
+sudo dnf install ./rhel9-postgresql17-documentdb-0.112.0-1.el9.x86_64.rpm
 ```
 
 ## Docker Images
@@ -60,4 +60,9 @@ docker run -dt -p 10260:10260 --name documentdb-container ghcr.io/documentdb/doc
 >
 > **Port Note:** Port `10260` is used by default in these instructions to avoid conflicts with other local database services. You can use port `27017` (the standard MongoDB port) or any other available port if you prefer. If you do, be sure to update the port number in both your `docker run` command and your connection string accordingly.
 
-> For `v0.111-0`, the GHCR repository resolves the `latest` tag for `documentdb-local`. Use a versioned image tag only if that tag is published in the registry for the release you want to run.
+`v0.112-0` publishes the following multi-architecture tags (linux/amd64 and linux/arm64) to GHCR:
+
+- `ghcr.io/documentdb/documentdb/documentdb-local:pg15-0.112.0`
+- `ghcr.io/documentdb/documentdb/documentdb-local:pg16-0.112.0`
+- `ghcr.io/documentdb/documentdb/documentdb-local:pg17-0.112.0`
+- `ghcr.io/documentdb/documentdb/documentdb-local:latest` (currently aliases `pg17-0.112.0`)

--- a/getting-started/vscode-extension-guide.md
+++ b/getting-started/vscode-extension-guide.md
@@ -355,6 +355,6 @@ The VS Code extension is particularly useful for migrating from MongoDB to Docum
 
 ## Next Steps
 
-- Learn about [DocumentDB Features]([../postgres-api/index.md](https://documentdb.io/docs/reference)) for advanced capabilities
+- Learn about [DocumentDB Features](https://documentdb.io/docs/reference) for advanced capabilities
 - Join our [Discord community](https://discord.gg/vH7bYu524D) for support and discussions
 - Report issues and contribute on [GitHub](https://github.com/documentdb/documentdb)

--- a/getting-started/vscode-quickstart.md
+++ b/getting-started/vscode-quickstart.md
@@ -103,7 +103,7 @@ Get started with DocumentDB using the Visual Studio Code extension for a seamles
 
 3. Getting support
    - Visit our [GitHub repository](https://github.com/microsoft/vscode-documentdb)
-   - Join the community discussions on [Discord]()
+   - Join the community on [Discord](https://discord.gg/vH7bYu524D)
    - Check documentation
 
 ## Next Steps

--- a/postgres-api/functions.md
+++ b/postgres-api/functions.md
@@ -1,61 +1,112 @@
 ---
 title: Functions
-description: Complete reference for PostgreSQL extension functions including CRUD operations, collection management, user management, and utilities.
+description: Reference for the PostgreSQL functions exposed by the pg_documentdb extension, including CRUD, schema, diagnostics, user and role management.
 ---
 
 # Functions
 
-Comprehensive documentation for PostgreSQL extension functions and their usage patterns.
+`pg_documentdb` exposes its public API as PostgreSQL functions in the `documentdb_api` schema. The MongoDB wire protocol commands handled by `pg_documentdb_gw` are implemented as thin wrappers over these functions, so you can call them directly from any PostgreSQL client (e.g. `psql`, `psycopg`, JDBC).
+
+All BSON parameters are encoded as PostgreSQL `bson` values (provided by the `pg_documentdb_core` extension). For example, you can pass a literal BSON spec using the cast `'{ ... }'::documentdb_core.bson` in `psql`.
+
+> The function signatures below show the public `documentdb_api` surface (or `documentdb_api_internal` where noted) as defined in `pg_documentdb/sql/udfs/`. A few wire-protocol entry points are implemented as PostgreSQL `PROCEDURE`s (and must be invoked with `CALL`); these are called out individually.
 
 ## CRUD Operations
 
-Functions for creating, reading, updating, and deleting documents in collections.
+Functions for creating, reading, updating, and deleting documents.
 
-| Function | Documentation |
-|----------|---------------|
-| `aggregate_cursor_first_page()` | [documentdb/wiki/Functions#aggregate_cursor_first_page](https://github.com/microsoft/documentdb/wiki/Functions#aggregate_cursor_first_page)
-| `count_query()` | [documentdb/wiki/Functions#count_query](https://github.com/microsoft/documentdb/wiki/Functions#count_query)
-| `cursor_get_more()` | [documentdb/wiki/Functions#cursor_get_more](https://github.com/microsoft/documentdb/wiki/Functions#cursor_get_more)
-| `delete()` | [documentdb/wiki/Functions#delete](https://github.com/microsoft/documentdb/wiki/Functions#delete)
-| `distinct_query()` | [documentdb/wiki/Functions#distinct_query](https://github.com/microsoft/documentdb/wiki/Functions#distinct_query)
-| `find_and_modify()` | [documentdb/wiki/Functions#find_and_modify](https://github.com/microsoft/documentdb/wiki/Functions#find_and_modify)
-| `find_cursor_first_page()` | [documentdb/wiki/Functions#find_cursor_first_page](https://github.com/microsoft/documentdb/wiki/Functions#find_cursor_first_page)
-| `insert()` | [documentdb/wiki/Functions#insert](https://github.com/microsoft/documentdb/wiki/Functions#insert)
-| `insert_one()` | [documentdb/wiki/Functions#insert_one](https://github.com/microsoft/documentdb/wiki/Functions#insert_one)
-| `list_collections_cursor_first_page()` | [documentdb/wiki/Functions#list_collections_cursor_first_page](https://github.com/microsoft/documentdb/wiki/Functions#list_collections_cursor_first_page)
-| `list_indexes_cursor_first_page()` | [documentdb/wiki/Functions#list_indexes_cursor_first_page](https://github.com/microsoft/documentdb/wiki/Functions#list_indexes_cursor_first_page)
-| `update()` | [documentdb/wiki/Functions#update](https://github.com/microsoft/documentdb/wiki/Functions#update)
-
-## Collection Management
-
-Functions for managing collections, views, and databases.
-
-| | Documentation |
+| Function | Description |
 | --- | --- |
-| `coll_mod()` | [documentdb/wiki/Functions#coll_mod](https://github.com/microsoft/documentdb/wiki/Functions#coll_mod)
-| `create_collection()` | [documentdb/wiki/Functions#create_collection](https://github.com/microsoft/documentdb/wiki/Functions#create_collection)
-| `create_collection_view()` | [documentdb/wiki/Functions#create_collection_view](https://github.com/microsoft/documentdb/wiki/Functions#create_collection_view)
-| `drop_collection()` | [documentdb/wiki/Functions#drop_collection](https://github.com/microsoft/documentdb/wiki/Functions#drop_collection)
-| `drop_database()` | [documentdb/wiki/Functions#drop_database](https://github.com/microsoft/documentdb/wiki/Functions#drop_database)
-| `rename_collection()` | [documentdb/wiki/Functions#rename_collection](https://github.com/microsoft/documentdb/wiki/Functions#rename_collection)
-| `shard_collection()` | [documentdb/wiki/Functions#shard_collection](https://github.com/microsoft/documentdb/wiki/Functions#shard_collection)
+| `documentdb_api.insert(database text, spec bson, documents bsonsequence DEFAULT NULL, transaction_id text DEFAULT NULL)` | Executes a MongoDB `insert` command. |
+| `documentdb_api_internal.insert_one(collection_id bigint, shard_key_value bigint, document bson, transaction_id text)` | Internal helper to insert a single document into a known collection. |
+| `documentdb_api.update(database text, spec bson, updates bsonsequence DEFAULT NULL, transaction_id text DEFAULT NULL)` | Executes a MongoDB `update` command. |
+| `documentdb_api.delete(database text, spec bson, deletes bsonsequence DEFAULT NULL, transaction_id text DEFAULT NULL)` | Executes a MongoDB `delete` command. |
+| `documentdb_api.find_and_modify(database text, spec bson, transaction_id text DEFAULT NULL)` | Executes a MongoDB `findAndModify` command. |
+| `CALL documentdb_api.bulkWrite(command bson, ops bsonsequence DEFAULT NULL, ns_info bsonsequence DEFAULT NULL, INOUT result bson, INOUT success boolean)` | Executes a MongoDB `bulkWrite` command (added in v0.111-0). Implemented as a `PROCEDURE`. |
+| `documentdb_api.find_cursor_first_page(database text, spec bson, cursor_id int8)` | Opens a cursor for a `find` command and returns its first page. |
+| `documentdb_api.aggregate_cursor_first_page(database text, spec bson, cursor_id int8)` | Opens a cursor for an `aggregate` command and returns its first page. |
+| `documentdb_api.list_collections_cursor_first_page(database text, spec bson, cursor_id int8)` | Opens a cursor for a `listCollections` command. |
+| `documentdb_api.list_indexes_cursor_first_page(database text, spec bson, cursor_id int8)` | Opens a cursor for a `listIndexes` command. |
+| `documentdb_api.cursor_get_more(database text, cursor_spec bson, continuation bson)` | Returns the next page for an existing cursor (`getMore`). |
+| `documentdb_api.count_query(database text, spec bson)` | Executes a MongoDB `count` command. |
+| `documentdb_api.distinct_query(database text, spec bson)` | Executes a MongoDB `distinct` command. |
+
+## Collection and Database Management
+
+Functions for managing collections, views, databases, and sharding.
+
+| Function | Description |
+| --- | --- |
+| `documentdb_api.create_collection(database text, collection text)` | Creates a new collection in the given database. |
+| `documentdb_api.create_collection_view(database text, spec bson)` | Creates a view backed by an aggregation pipeline. |
+| `documentdb_api.drop_collection(database text, collection text, write_concern bson DEFAULT NULL, collection_uuid uuid DEFAULT NULL, track_changes bool DEFAULT true)` | Drops a collection. |
+| `documentdb_api.rename_collection(database text, collection text, target_name text, drop_target bool DEFAULT false)` | Renames a collection. |
+| `documentdb_api.drop_database(database text, write_concern bson DEFAULT NULL)` | Drops a database and all of its collections. |
+| `documentdb_api.list_databases(spec bson)` | Returns information about all databases (added in v0.102-0). |
+| `documentdb_api.shard_collection(database text, collection text, shard_key bson, is_reshard bool DEFAULT true)` | Shards or reshards a collection on the supplied key. |
+| `documentdb_api.reshard_collection(shard_key_spec bson)` | Re-shards a collection from a wire-protocol BSON spec. |
+| `documentdb_api.coll_mod(database text, collection text, spec bson)` | Executes a MongoDB `collMod` command. |
+| `documentdb_api.compact(spec bson)` | Compacts a collection's data and indexes (added in v0.104-0; requires the `documentdb.enableCompact` GUC in versions prior to v0.109-0). |
+
+## Index Management
+
+| Function | Description |
+| --- | --- |
+| `documentdb_api_internal.create_indexes_non_concurrently(database text, spec bson, skip_check_collection_create bool DEFAULT false)` | Creates one or more indexes in the foreground. Lives in the internal schema. |
+| `documentdb_api_internal.create_index_background(database text, spec bson)` | Schedules background index builds via the index queue (the default since v0.104-0). |
+| `CALL documentdb_api.drop_indexes(database text, spec bson, INOUT retval bson DEFAULT NULL)` | Drops indexes via the wire-protocol `dropIndexes` command. Implemented as a `PROCEDURE`. |
+
+## Diagnostic and Administration Commands
+
+Functions backing diagnostic and administrative wire protocol commands.
+
+| Function | Description |
+| --- | --- |
+| `documentdb_api.coll_stats(database text, collection text, scale float8 DEFAULT 1)` | Returns storage and index statistics for a collection (`collStats`). |
+| `documentdb_api.db_stats(database text, scale float8 DEFAULT 1, free_storage bool DEFAULT false)` | Returns storage statistics for a database (`dbStats`). |
+| `documentdb_api.validate(database text, validate_spec bson)` | Validates a collection's indexes (`validate`). |
+| `documentdb_api.connection_status(spec bson)` | Returns authentication and role information for the current connection (`connectionStatus`, added in v0.105-0). |
+| `documentdb_api.kill_op(command_spec bson)` | Cancels a running operation by op id (`killOp`, added in v0.109-0). |
+| `documentdb_api.current_op_command(spec bson)` | Backs the `currentOp` wire-protocol command (added in v0.101-0). The `$currentOp` aggregation stage uses the internal `documentdb_api_internal.current_op_aggregation(spec bson)` set-returning helper. |
 
 ## User Management
 
-Functions for creating, updating, and managing database users.
+Functions for creating, updating, and managing database users. Backed by the wire protocol `createUser`, `dropUser`, `updateUser`, and `usersInfo` commands.
 
-| | Documentation |
+| Function | Description |
 | --- | --- |
-| `create_user()` | [documentdb/wiki/Functions#create_user](https://github.com/microsoft/documentdb/wiki/Functions#create_user)
-| `drop_user()` | [documentdb/wiki/Functions#drop_user](https://github.com/microsoft/documentdb/wiki/Functions#drop_user)
-| `update_user()` | [documentdb/wiki/Functions#update_user](https://github.com/microsoft/documentdb/wiki/Functions#update_user)
-| `users_info()` | [documentdb/wiki/Functions#users_info](https://github.com/microsoft/documentdb/wiki/Functions#users_info)
+| `documentdb_api.create_user(spec bson)` | Creates a new user. |
+| `documentdb_api.drop_user(spec bson)` | Drops an existing user. |
+| `documentdb_api.update_user(spec bson)` | Updates an existing user (password, roles, etc.). |
+| `documentdb_api.users_info(spec bson)` | Returns information about one or more users. |
+
+## Role Management
+
+Role management is supported since v0.106-0 (`createRole`, `rolesInfo`) and v0.108-0 (`dropRole`).
+
+| Function | Description |
+| --- | --- |
+| `documentdb_api.create_role(spec bson)` | Creates a new role. |
+| `documentdb_api.drop_role(spec bson)` | Drops an existing role. |
+| `documentdb_api.update_role(spec bson)` | Updates an existing role's privileges or inherited roles. |
+| `documentdb_api.roles_info(spec bson)` | Returns information about one or more roles. |
 
 ## Utility Functions
 
-Functions for retrieving version information and other utility operations.
-
-| Function | Documentation |
+| Function | Description |
 | --- | --- |
-| `binary_extended_version()` | [documentdb/wiki/Functions#binary_extended_version](https://github.com/microsoft/documentdb/wiki/Functions#binary_extended_version)
-| `binary_version()` | [documentdb/wiki/Functions#binary_version](https://github.com/microsoft/documentdb/wiki/Functions#binary_version)
+| `documentdb_api.binary_version()` | Returns the running binary version of the `pg_documentdb` shared library. |
+| `documentdb_api.binary_extended_version()` | Returns the extended binary version, including build metadata. |
+
+## Example
+
+To call any of these directly from `psql`:
+
+```sql
+SELECT documentdb_api.insert(
+    'mydb',
+    '{ "insert": "users", "documents": [ { "name": "alice" } ] }'::documentdb_core.bson
+);
+```
+
+For more complete examples (cursors, aggregation, sharding) see the [API Reference](https://documentdb.io/docs/api-reference).

--- a/postgres-api/index.md
+++ b/postgres-api/index.md
@@ -1,15 +1,15 @@
 ---
 title: Components
-description: Learn about pg_documentdb_core and pg_documentdb_api PostgreSQL extensions that enable BSON support and document operations in Postgres.
+description: Learn about pg_documentdb_core, pg_documentdb, and pg_documentdb_gw — the PostgreSQL extensions that enable BSON support, document operations, and MongoDB wire protocol compatibility in Postgres.
 ---
 
 # Components
 
-The DocumentDB implementation consists of two key PostgreSQL extensions that work together to provide MongoDB-compatible document database functionality within PostgreSQL.
+The DocumentDB implementation consists of three PostgreSQL extensions that work together to provide MongoDB-compatible document database functionality on top of PostgreSQL.
 
 ## pg_documentdb_core
 
-pg_documentdb_core is a PostgreSQL extension that introduces BSON datatype support and operations for native Postgres. This core component is essential for enabling document-oriented NoSQL capabilities within a PostgreSQL environment. It provides the foundational data structures and functions required to handle BSON data types, which are crucial for performing CRUD operations on documents.
+`pg_documentdb_core` is a PostgreSQL extension that introduces BSON datatype support and operations for native Postgres. This core component is essential for enabling document-oriented NoSQL capabilities within a PostgreSQL environment. It provides the foundational data structures and functions required to handle BSON data types, which are crucial for performing CRUD operations on documents.
 
 ### Key Features
 
@@ -19,18 +19,38 @@ pg_documentdb_core is a PostgreSQL extension that introduces BSON datatype suppo
 
 - **Extensibility:** Serves as the core building block for additional functionalities and extensions within the DocumentDB ecosystem.
 
-## pg_documentdb_api
+## pg_documentdb
 
-pg_documentdb_api is the public API surface for DocumentDB, providing CRUD functionality on documents stored in the database. This component leverages the capabilities of pg_documentdb_core to offer a comprehensive set of APIs for managing document data within PostgreSQL.
+`pg_documentdb` is the public API surface for DocumentDB, providing CRUD functionality on documents stored in the database. This component leverages the capabilities of `pg_documentdb_core` to offer a comprehensive set of APIs for managing document data within PostgreSQL.
 
 ### Key Features
 
 - **CRUD Operations:** Provides a rich set of APIs for creating, reading, updating, and deleting documents.
 
-- **Advanced Queries:** Supports complex queries, including full-text searches, geospatial queries, and vector embeddings.
+- **Advanced Queries:** Supports complex queries, including full-text searches, geospatial queries, vector search, and aggregation pipelines.
 
-- **Integration:** Works seamlessly with pg_documentdb_core to deliver robust document management capabilities.
+- **Index Management:** Single-field, compound, multi-key, partial, unique, TTL, text, geospatial, and vector indexes.
+
+- **User and Role Management:** Built-in commands for managing users, roles, and SCRAM authentication.
+
+- **Integration:** Works seamlessly with `pg_documentdb_core` to deliver robust document management capabilities.
 
 ### Usage
 
-To use pg_documentdb_api, you need to have pg_documentdb_core installed and configured in your PostgreSQL environment. Once set up, you can leverage the APIs provided by pg_documentdb_api to perform various document operations.
+To use `pg_documentdb`, you need to have `pg_documentdb_core` installed and configured in your PostgreSQL environment. Once set up, you can leverage the APIs provided by `pg_documentdb` to perform document operations from any PostgreSQL client. For the full list of callable functions, see [Functions](functions.md).
+
+## pg_documentdb_gw
+
+`pg_documentdb_gw` is the gateway protocol translation layer that converts the user's MongoDB wire protocol commands into PostgreSQL queries against the `pg_documentdb` API. It is what allows MongoDB-compatible drivers and tools (`mongosh`, PyMongo, the official MongoDB Node.js driver, the VS Code extension, and others) to talk to a DocumentDB instance unmodified.
+
+### Key Features
+
+- **MongoDB Wire Protocol:** Parses MongoDB wire protocol messages (`OP_MSG`, `OP_QUERY`, `OP_INSERT`, etc.) and dispatches them to the corresponding `pg_documentdb` SQL functions.
+
+- **Authentication:** Supports SCRAM-SHA-256 and Plain authentication (including EntraId token-based Plain Auth introduced in v0.106-0).
+
+- **TLS Termination:** Terminates TLS on the gateway port (default `10260`), allowing drivers to connect over the standard MongoDB-style `mongodb://` connection string with `tls=true`.
+
+- **Cursor and Session Management:** Translates `getMore`, `killCursors`, `killSessions`, and `killOp` commands to the corresponding backend operations.
+
+- **Deployment Options:** Can be run as a standalone process (the default in the `documentdb-local` container) or, since v0.108-0, as a PostgreSQL background worker via the `pg_documentdb_gw_host` extension.


### PR DESCRIPTION
## Summary

Sync the documentation with the upstream `documentdb/documentdb` repo at **v0.112-0** (released 2026-05-26). The docs had drifted across several releases and several pages contained content that no longer matched the code.

## Fixed

### Critical bugs
- **`getting-started/mongo-shell-quickstart.md`** — file body had been overwritten with a duplicate of `nodejs-setup.md` (the title still said "MongoDB Shell Quick Start"). Restored as a real mongosh quickstart with TLS connection, basic CRUD, indexes, aggregation, and the **actual** DocumentDB `cosmosSearch`/`cosmosSearchOptions` vector-search syntax (verified against `pg_documentdb/src/test/regress/sql/bson_aggregation_pipeline_tests.sql`).
- **`postgres-api/index.md`** + **`getting-started/index.md`** — replaced phantom extension name `pg_documentdb_api` (does not exist) with the real `pg_documentdb`, and added the missing `pg_documentdb_gw` gateway component.
- **`postgres-api/functions.md`** — every function row linked to `github.com/microsoft/documentdb/wiki`, which is the old (pre-LF) org. Rewrote the page:
  - Removed dead wiki links.
  - Corrected signatures: `bulkWrite` and `drop_indexes` are `PROCEDURE`s (must be invoked with `CALL`); `shard_collection` default is `is_reshard=true`; `drop_database` takes `(database, write_concern)`; `create_indexes_non_concurrently` lives in `documentdb_api_internal`; public `currentOp` entry point is `current_op_command`.
  - Added UDFs shipped since v0.103-0: `compact`, `connection_status`, `current_op_command`, `kill_op`, `validate`, `coll_stats`, `db_stats`, `list_databases`, `create_role`/`drop_role`/`update_role`/`roles_info`, `bulkWrite`, `reshard_collection`.

### Version bump
- **`getting-started/prebuilt-packages.md`** — bumped v0.111-0 → **v0.112-0** (release date, package matrix, install commands, Docker tags) using the GitHub release notes for `v0.112-0`.

### New content
- **`api-reference/operators/aggregation/$bucketauto.md`** — new page for `$bucketAuto` (shipped v0.105-0). Granularity values (`POWERSOF2`, `1-2-5`, `R5`–`R80`, `E6`–`E192`) verified against `pg_documentdb/src/aggregation/bson_bucket_auto.c`.

### Small bugs
- Typo `DoucmenttDB` in `documentdb-local/index.md`.
- Empty `[Discord]()` link in `vscode-quickstart.md`.
- Malformed next-steps link `[…]([url1](url2))` in `vscode-extension-guide.md`.

## Validation
- Re-grepped: zero remaining `pg_documentdb_api` or `microsoft/documentdb/wiki` references in the docs.
- Function signatures cross-checked against `pg_documentdb/sql/udfs/**/*--latest.sql` and `pg_documentdb/src/metadata/metadata_cache.c` (schema `documentdb_api`).
- Vector-search syntax verified against upstream regression tests.
- Reviewed by the rubber-duck agent; signature inaccuracies and an unverifiable `bson_update_document`-dropped claim were caught and corrected before commit.

## Out of scope (deferred to follow-up PRs)
- Per-command pages for new admin commands (`compact`, `currentOp`, `killOp`, `killSessions`, role/user commands).
- Rewriting the empty Architecture section.
- Removing the fake `documentdb_api` Python import in `python-setup.md`.
- Adding TLS guidance to all language quickstart guides.