### PR TITLE
Use TLS and credentials in getting-started connection examples

### DIFF
--- a/getting-started/nodejs-setup.md
+++ b/getting-started/nodejs-setup.md
@@ -52,10 +52,12 @@ Before connecting from Node.js, make sure you have a running DocumentDB instance
 
 ## Connecting to DocumentDB
 
+DocumentDB Local requires TLS and authentication on the gateway port. Connect with the username and password you set when starting the container, and because the container generates a new self-signed certificate on each start, the simplest local setup skips certificate validation with `tlsAllowInvalidCertificates=true` (in production, provide the gateway certificate instead).
+
 ```javascript
 const { MongoClient } = require('mongodb');
 
-const uri = 'mongodb://localhost:27017';
+const uri = 'mongodb://<YOUR_USERNAME>:<YOUR_PASSWORD>@localhost:10260/?tls=true&tlsAllowInvalidCertificates=true';
 const client = new MongoClient(uri);
 
 async function connect() {

--- a/getting-started/python-setup.md
+++ b/getting-started/python-setup.md
@@ -48,6 +48,8 @@ Learn how to set up and use DocumentDB with Python using the official MongoDB Py
 
 ## Connecting to DocumentDB
 
+DocumentDB Local requires TLS and authentication on the gateway port. Connect with the username and password you set when starting the container, and because the container generates a new self-signed certificate on each start, the simplest local setup skips certificate validation with `tlsAllowInvalidCertificates=true` (in production, provide the gateway certificate instead).
+
 1. Basic Connection
    ```python
    import pymongo
@@ -55,7 +57,7 @@ Learn how to set up and use DocumentDB with Python using the official MongoDB Py
 
    # Create a MongoDB client and open a connection to DocumentDB
    client = pymongo.MongoClient(
-       'mongodb://localhost:10260'
+       'mongodb://<YOUR_USERNAME>:<YOUR_PASSWORD>@localhost:10260/?tls=true&tlsAllowInvalidCertificates=true'
    )
 
    # Specify the database to be used
@@ -69,7 +71,7 @@ Learn how to set up and use DocumentDB with Python using the official MongoDB Py
    ```python
    # With username and password
    client = pymongo.MongoClient(
-       'mongodb://username:password@localhost:10260'
+       'mongodb://username:password@localhost:10260/?tls=true&tlsAllowInvalidCertificates=true'
    )
    ```
 
@@ -77,7 +79,7 @@ Learn how to set up and use DocumentDB with Python using the official MongoDB Py
    ```python
    # With additional options
    client = pymongo.MongoClient(
-       'mongodb://localhost:10260',
+       'mongodb://<YOUR_USERNAME>:<YOUR_PASSWORD>@localhost:10260/?tls=true&tlsAllowInvalidCertificates=true',
        maxPoolSize=50,
        retryWrites=False,
        w='majority'
@@ -261,7 +263,7 @@ from pymongo import MongoClient
 from datetime import datetime
 
 app = Flask(__name__)
-client = MongoClient('mongodb://localhost:27017/')
+client = MongoClient('mongodb://<YOUR_USERNAME>:<YOUR_PASSWORD>@localhost:10260/?tls=true&tlsAllowInvalidCertificates=true')
 db = client.sample_database
 
 @app.route('/users', methods=['GET'])


### PR DESCRIPTION
## What

The DocumentDB Local gateway enforces TLS and requires authentication on port 10260. The Python and Node.js getting-started quickstarts still used plain `mongodb://` connection strings (and one `localhost:27017`), which now fail with a connection reset/refusal.

## Changes

- `getting-started/python-setup.md`: all connection strings now use `mongodb://<YOUR_USERNAME>:<YOUR_PASSWORD>@localhost:10260/?tls=true&tlsAllowInvalidCertificates=true` (basic, authentication, options, and sample app), plus a short TLS + authentication note.
- `getting-started/nodejs-setup.md`: replaced the `localhost:27017` plain URI with the TLS + credentials form and added the note.

## Verification

Tested end-to-end against the `documentdb-local` container:

- Plain URI -> connection reset/refused.
- TLS without credentials -> transport connects but operations fail ("not authenticated yet").
- TLS + credentials -> ping, insert, and find all succeed (verified with pymongo, the Node.js driver, and mongosh).
