### PR TITLE
Update prebuilt-packages docs for v0.113-0 release

### DIFF
--- a/getting-started/prebuilt-packages.md
+++ b/getting-started/prebuilt-packages.md
@@ -9,36 +9,36 @@ Download and install DocumentDB using the pre-built packages and container image
 
 ## Latest Release
 
-The current release is [`v0.112-0`](https://github.com/documentdb/documentdb/releases/tag/v0.112-0), published on 2026-05-26.
+The current release is [`v0.113-0`](https://github.com/documentdb/documentdb/releases/tag/v0.113-0), published on 2026-06-22.
 
-This release eliminates subquery migration for many `$group` aggregations, adds index pushdown for `$group` when `_id` is a multi-field document expression, expands collation support for non-unique ordered indexes (`$lt`/`$lte`/`$ne`/`$not` combinations), migrates streaming query execution off the SPI cursor path, and ships several crash fixes for `BSONFIRSTN`/`BSONLASTN`/`BSONMAXN`/`BSONMINN` on empty sharded collections.
+This release adds the `EnableSortPushToAccumulator` GUC to control pushing sort order into the accumulator for the `$sortGroup` stage, extends collation support for non-unique ordered indexes to `$in`/`$nin` (without ordered scans), adds pruning of dead index entries on ordered TTL indexes, and enables index-only scans for `$group` accumulators whose referenced fields are fully covered by a composite index.
 
-> `v0.112-0` publishes Linux packages only. macOS and Windows installers are not part of this release.
+> `v0.113-0` publishes Linux packages only. macOS and Windows installers are not part of this release.
 
 ## Package Matrix
 
 | Package family | Supported distributions | PostgreSQL versions | Architectures | Downloads |
 | --- | --- | --- | --- | --- |
-| DEB | Debian 11, Debian 12, Debian 13, Ubuntu 22.04, Ubuntu 24.04 | 16, 17, 18 | amd64, arm64 | [v0.112-0 release assets](https://github.com/documentdb/documentdb/releases/tag/v0.112-0) |
-| RPM | RHEL 8, RHEL 9 | 16, 17, 18 | x86_64, aarch64 | [v0.112-0 release assets](https://github.com/documentdb/documentdb/releases/tag/v0.112-0) |
+| DEB | Debian 11, Debian 12, Debian 13, Ubuntu 22.04, Ubuntu 24.04 | 16, 17, 18 | amd64, arm64 | [v0.113-0 release assets](https://github.com/documentdb/documentdb/releases/tag/v0.113-0) |
+| RPM | RHEL 8, RHEL 9 | 16, 17, 18 | x86_64, aarch64 | [v0.113-0 release assets](https://github.com/documentdb/documentdb/releases/tag/v0.113-0) |
 
 Choose the asset whose filename matches your Linux distribution, PostgreSQL major version, and CPU architecture. For example:
 
-- `ubuntu24.04-postgresql-17-documentdb_0.112-0_amd64.deb`
-- `rhel9-postgresql17-documentdb-0.112.0-1.el9.x86_64.rpm`
+- `ubuntu24.04-postgresql-17-documentdb_0.113-0_amd64.deb`
+- `rhel9-postgresql17-documentdb-0.113.0-1.el9.x86_64.rpm`
 
 ## Install a DEB Package
 
 ```bash
-curl -LO https://github.com/documentdb/documentdb/releases/download/v0.112-0/ubuntu24.04-postgresql-17-documentdb_0.112-0_amd64.deb
-sudo apt install ./ubuntu24.04-postgresql-17-documentdb_0.112-0_amd64.deb
+curl -LO https://github.com/documentdb/documentdb/releases/download/v0.113-0/ubuntu24.04-postgresql-17-documentdb_0.113-0_amd64.deb
+sudo apt install ./ubuntu24.04-postgresql-17-documentdb_0.113-0_amd64.deb
 ```
 
 ## Install an RPM Package
 
 ```bash
-curl -LO https://github.com/documentdb/documentdb/releases/download/v0.112-0/rhel9-postgresql17-documentdb-0.112.0-1.el9.x86_64.rpm
-sudo dnf install ./rhel9-postgresql17-documentdb-0.112.0-1.el9.x86_64.rpm
+curl -LO https://github.com/documentdb/documentdb/releases/download/v0.113-0/rhel9-postgresql17-documentdb-0.113.0-1.el9.x86_64.rpm
+sudo dnf install ./rhel9-postgresql17-documentdb-0.113.0-1.el9.x86_64.rpm
 ```
 
 ## Docker Images
@@ -60,9 +60,9 @@ docker run -dt -p 10260:10260 --name documentdb-container ghcr.io/documentdb/doc
 >
 > **Port Note:** Port `10260` is used by default in these instructions to avoid conflicts with other local database services. You can use port `27017` (the standard MongoDB port) or any other available port if you prefer. If you do, be sure to update the port number in both your `docker run` command and your connection string accordingly.
 
-`v0.112-0` publishes the following multi-architecture tags (linux/amd64 and linux/arm64) to GHCR:
+`v0.113-0` publishes the following multi-architecture tags (linux/amd64 and linux/arm64) to GHCR:
 
-- `ghcr.io/documentdb/documentdb/documentdb-local:pg15-0.112.0`
-- `ghcr.io/documentdb/documentdb/documentdb-local:pg16-0.112.0`
-- `ghcr.io/documentdb/documentdb/documentdb-local:pg17-0.112.0`
-- `ghcr.io/documentdb/documentdb/documentdb-local:latest` (currently aliases `pg17-0.112.0`)
+- `ghcr.io/documentdb/documentdb/documentdb-local:pg15-0.113.0`
+- `ghcr.io/documentdb/documentdb/documentdb-local:pg16-0.113.0`
+- `ghcr.io/documentdb/documentdb/documentdb-local:pg17-0.113.0`
+- `ghcr.io/documentdb/documentdb/documentdb-local:latest` (currently aliases `pg17-0.113.0`)


### PR DESCRIPTION
Updates `getting-started/prebuilt-packages.md` for the [v0.113-0 release](https://github.com/documentdb/documentdb/releases/tag/v0.113-0) (published 2026-06-22):

- Latest Release version + date (v0.112-0 / 2026-05-26 → v0.113-0 / 2026-06-22) and refreshed release summary
- Package matrix release-asset links, example `.deb`/`.rpm` filenames, and DEB/RPM `curl`+install commands → v0.113-0
- GHCR image tags `pg15/16/17-0.113.0` and the `latest` alias

All package/image references verified against the published v0.113-0 release assets and GHCR manifests.