### PR TITLE
Add v0.114-0 configuration reference (draft)

### DIFF
--- a/postgres-api/configuration.md
+++ b/postgres-api/configuration.md
@@ -1,0 +1,54 @@
+---
+title: Configuration
+description: Server GUCs and gateway environment variables for configuring DocumentDB, including the defaults introduced in v0.114-0.
+---
+
+# Configuration
+
+DocumentDB is configured at two layers: the PostgreSQL extension (via GUCs in `postgresql.conf`) and the gateway process (via environment variables or a JSON config file). This page covers the most commonly adjusted settings, including behavior that changed in **v0.114-0**.
+
+## Extension GUCs
+
+`pg_documentdb` exposes tuning and feature-flag settings as PostgreSQL GUCs under the `documentdb.` prefix. Set them in `postgresql.conf`, per session with `SET`, or per role/database with `ALTER ROLE ... SET`.
+
+### Schema validation
+
+| GUC | Default | Description |
+| --- | --- | --- |
+| `documentdb.enableSchemaValidation` | `on` (since v0.114-0) | Enforces collection `$jsonSchema` validators on write operations. When `off`, a collection's validator is stored but not enforced. |
+
+Collections created with a `validator` (and a `validationLevel` other than `off`) have their JSON Schema enforced on `insert`, `update`, and `findAndModify`. Prior to v0.114-0 enforcement was opt-in; it is now enabled by default.
+
+### Non-blocking unique index builds
+
+| GUC | Default | Description |
+| --- | --- | --- |
+| `documentdb.enableNonBlockingUniqueIndexBuild` | `on` (since v0.114-0) | Builds unique ordered indexes without holding a long write lock, using `CREATE INDEX CONCURRENTLY` with post-processing to register the exclusion constraint and validate existing rows. |
+
+When enabled, creating a unique index on an existing collection no longer blocks concurrent writes for the duration of the build.
+
+## Gateway configuration
+
+The gateway (`pg_documentdb_gw`) reads its settings from a JSON configuration file and/or `DOCUMENTDB_*` environment variables. Environment variables override the JSON file, which makes them convenient for systemd-managed and container deployments. *(Environment-variable configuration added in v0.114-0.)*
+
+| Environment variable | Purpose |
+| --- | --- |
+| `DOCUMENTDB_PG_URL_FILE` | Path to a file containing the PostgreSQL connection URL, read at startup. For package-managed installs the URL must not contain a password — the gateway connects over a local Unix socket using peer authentication. |
+| `DOCUMENTDB_LISTEN_ADDR` | Address the gateway listens on, in `host:port` or `:port` form (for example `:10260`). |
+| `DOCUMENTDB_TLS_CERT_FILE` | Path to the TLS certificate file. |
+| `DOCUMENTDB_TLS_KEY_FILE` | Path to the TLS private key file. |
+| `DOCUMENTDB_TLS_AUTO_GENERATE` | When `true`, auto-generate a self-signed certificate if no cert/key files are provided. |
+| `DOCUMENTDB_TLS_STATE_DIR` | Directory where an auto-generated certificate/key is written and re-read on restart (defaults to `/var/lib/documentdb-gateway/tls`). |
+| `DOCUMENTDB_LOG_LEVEL` | Log level for the gateway's tracing subscriber (for example `info`, `debug`). |
+
+For systemd-managed installs these are typically set through the unit's `EnvironmentFile` (for example `gateway.env`).
+
+### Connectivity check
+
+The gateway binary provides a `check` subcommand (added in v0.114-0) that acts as a post-install connectivity probe:
+
+```bash
+documentdb-gateway check [--config <path>]
+```
+
+It connects to the configured PostgreSQL backend, runs the same startup validation as the service-start path, and reports the installed `documentdb` extension version. It exits `0` on success and `1` on failure (printing a human-readable message and a hint on stderr), which makes it suitable for post-install smoke tests and health checks.

--- a/postgres-api/navigation.yml
+++ b/postgres-api/navigation.yml
@@ -2,3 +2,5 @@
   link: index.md
 - title: Functions
   link: functions.md
+- title: Configuration
+  link: configuration.md


### PR DESCRIPTION
**Draft** — optional feature docs for v0.114-0, split out from the version-bump PR (#52) so it can be reviewed independently.

Adds `postgres-api/configuration.md` (+ nav entry) documenting the user-facing config surface that changed in v0.114-0:

- `documentdb.enableSchemaValidation` — **now on by default**; enforces `\` validators on writes.
- `documentdb.enableNonBlockingUniqueIndexBuild` — **now on by default**; unique index builds via `CREATE INDEX CONCURRENTLY`.
- Gateway `DOCUMENTDB_*` environment variables + the `documentdb-gateway check` connectivity-probe subcommand.

Content is sourced from the extension GUC definitions (`feature_flag_configs.c`) and the gateway `setup.rs` / `check.rs`.

**For reviewers:**
- The OSS release does not yet publish a gateway package; the gateway section describes the binary's configuration surface (standalone / systemd / container deployments). Please confirm framing.
- A cross-link from the `pg_documentdb_gw` section of `index.md` (Components) could aid discoverability — happy to add if desired.