### PR TITLE
Document $vectorSearch, $graphLookup, $project, and $limit

### DIFF
--- a/api-reference/operators/aggregation/$graphlookup.md
+++ b/api-reference/operators/aggregation/$graphlookup.md
@@ -1,0 +1,200 @@
+---
+title: $graphLookup
+description: The $graphLookup stage in the aggregation pipeline performs a recursive search across documents in a collection.
+type: operators
+category: aggregation
+---
+
+# $graphLookup
+
+The `$graphLookup` stage in the aggregation pipeline performs a recursive search over a collection and attaches the documents it reaches to each input document. Use it for hierarchies and graphs — reporting chains, category trees, referral networks, or any relationship you would otherwise have to walk with repeated queries from the application.
+
+## Syntax
+
+```javascript
+{
+  $graphLookup: {
+    from: <collection>,
+    startWith: <expression>,
+    connectFromField: <string>,
+    connectToField: <string>,
+    as: <string>,
+    maxDepth: <nonNegativeInteger>,
+    depthField: <string>,
+    restrictSearchWithMatch: <document>
+  }
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`from`** | Required. The collection to search recursively. |
+| **`startWith`** | Required. An expression giving the value (or array of values) that begins the traversal. |
+| **`connectFromField`** | Required. The field whose value is carried into the next round of the search. |
+| **`connectToField`** | Required. The field in the `from` collection matched against the incoming value. |
+| **`as`** | Required. Name of the array field added to each input document to hold the matched documents. Cannot begin with `$`. |
+| **`maxDepth`** | Optional. A non-negative integer bounding how many recursive rounds run. Omit for an unbounded search. `0` visits only the documents matched by `startWith`. |
+| **`depthField`** | Optional. Name of a field added to each matched document recording the recursion depth at which it was found, starting at `0`. Cannot begin with `$`. |
+| **`restrictSearchWithMatch`** | Optional. A query document that matched documents must also satisfy. Documents that fail it are excluded, and the traversal does not continue through them. |
+
+Any other parameter is rejected with `Unrecognized parameter supplied to stage $graphlookup`.
+
+## Examples
+
+The examples on this page use the following documents in an `employees` collection, each pointing at the person they report to by name.
+
+```json
+[
+  { "_id": 1, "name": "Ana", "title": "VP, Retail", "reportsTo": null },
+  { "_id": 2, "name": "Bo", "title": "Regional Manager", "reportsTo": "Ana" },
+  { "_id": 3, "name": "Cai", "title": "Store Manager", "reportsTo": "Bo" },
+  { "_id": 4, "name": "Dev", "title": "Shift Lead", "reportsTo": "Cai" },
+  { "_id": 5, "name": "Eve", "title": "Associate", "reportsTo": "Dev" }
+]
+```
+
+### Example 1: Walking a reporting chain
+
+This query starts at Eve and follows `reportsTo` all the way to the top of the organization.
+
+```javascript
+db.employees.aggregate([
+  { $match: { name: "Eve" } },
+  {
+    $graphLookup: {
+      from: "employees",
+      startWith: "$reportsTo",
+      connectFromField: "reportsTo",
+      connectToField: "name",
+      as: "managementChain"
+    }
+  },
+  { $project: { _id: 0, name: 1, "managementChain.name": 1 } }
+])
+```
+
+This query returns the following result:
+
+```json
+[
+  {
+    "name": "Eve",
+    "managementChain": [
+      { "name": "Ana" },
+      { "name": "Bo" },
+      { "name": "Cai" },
+      { "name": "Dev" }
+    ]
+  }
+]
+```
+
+One pipeline reaches every ancestor. The order of the `as` array is not defined — use `depthField` when you need to know how far away each match was.
+
+### Example 2: Bounding the search and recording depth
+
+This query walks at most one extra level past the starting point and tags each match with the depth at which it was found.
+
+```javascript
+db.employees.aggregate([
+  { $match: { name: "Eve" } },
+  {
+    $graphLookup: {
+      from: "employees",
+      startWith: "$reportsTo",
+      connectFromField: "reportsTo",
+      connectToField: "name",
+      as: "managementChain",
+      maxDepth: 1,
+      depthField: "level"
+    }
+  },
+  {
+    $project: {
+      _id: 0,
+      name: 1,
+      "managementChain.name": 1,
+      "managementChain.level": 1
+    }
+  }
+])
+```
+
+This query returns the following result:
+
+```json
+[
+  {
+    "name": "Eve",
+    "managementChain": [
+      { "name": "Cai", "level": 1 },
+      { "name": "Dev", "level": 0 }
+    ]
+  }
+]
+```
+
+Dev is Eve's direct manager, so it sits at depth `0`; Cai is one round further out at depth `1`. With `maxDepth: 1`, the search stops there.
+
+### Example 3: Filtering which documents the search may traverse
+
+This query follows the chain but only through people whose title contains `Lead` or `Manager`.
+
+```javascript
+db.employees.aggregate([
+  { $match: { name: "Eve" } },
+  {
+    $graphLookup: {
+      from: "employees",
+      startWith: "$reportsTo",
+      connectFromField: "reportsTo",
+      connectToField: "name",
+      as: "managementChain",
+      restrictSearchWithMatch: { title: { $regex: "Lead|Manager" } }
+    }
+  },
+  {
+    $project: {
+      _id: 0,
+      name: 1,
+      "managementChain.name": 1,
+      "managementChain.title": 1
+    }
+  }
+])
+```
+
+This query returns the following result:
+
+```json
+[
+  {
+    "name": "Eve",
+    "managementChain": [
+      { "name": "Bo", "title": "Regional Manager" },
+      { "name": "Cai", "title": "Store Manager" },
+      { "name": "Dev", "title": "Shift Lead" }
+    ]
+  }
+]
+```
+
+Ana is reachable but her title is `VP, Retail`, so she is filtered out — and because the traversal cannot pass through an excluded document, anyone above her would be unreachable as well.
+
+## Error cases
+
+| Problem | Error |
+| --- | --- |
+| `connectFromField` or `connectToField` missing | `Both 'connectFrom' and 'connectTo' operators must be provided for a $graphLookup operation.` |
+| `from` missing | `$graphLookup requires 'from' field to be specified` |
+| `as` missing | `$graphLookup requires 'as' field to be specified` |
+| `startWith` missing | `You must provide a 'startWith' parameter when performing a $graphLookup operation` |
+| Unknown parameter | `Unrecognized parameter supplied to stage $graphlookup: <name>` |
+| Negative `maxDepth` | `The value of graphlookup.maxDepth must always be a non-negative integer number.` |
+
+## Related
+
+- [`$lookup`](../%24lookup/) — joins a single level instead of recursing.
+- [`$unwind`](../%24unwind/) — flattens the array produced in the `as` field.

--- a/api-reference/operators/aggregation/$graphlookup.md
+++ b/api-reference/operators/aggregation/$graphlookup.md
@@ -30,14 +30,16 @@ The `$graphLookup` stage in the aggregation pipeline performs a recursive search
 
 | Parameter | Description |
 | --- | --- |
-| **`from`** | Required. The collection to search recursively. |
+| **`from`** | Required. The collection to search recursively. **Cannot be a sharded collection** — see [Limitations](#limitations). |
 | **`startWith`** | Required. An expression giving the value (or array of values) that begins the traversal. |
-| **`connectFromField`** | Required. The field whose value is carried into the next round of the search. |
-| **`connectToField`** | Required. The field in the `from` collection matched against the incoming value. |
+| **`connectFromField`** | Required. The field whose value is carried into the next round of the search. Cannot begin with `$`. |
+| **`connectToField`** | Required. The field in the `from` collection matched against the incoming value. Cannot begin with `$`. |
 | **`as`** | Required. Name of the array field added to each input document to hold the matched documents. Cannot begin with `$`. |
 | **`maxDepth`** | Optional. A non-negative integer bounding how many recursive rounds run. Omit for an unbounded search. `0` visits only the documents matched by `startWith`. |
 | **`depthField`** | Optional. Name of a field added to each matched document recording the recursion depth at which it was found, starting at `0`. Cannot begin with `$`. |
-| **`restrictSearchWithMatch`** | Optional. A query document that matched documents must also satisfy. Documents that fail it are excluded, and the traversal does not continue through them. |
+| **`restrictSearchWithMatch`** | Optional. A query document that matched documents must also satisfy. Documents that fail it are excluded, and the traversal does not continue through them. `$near`, `$nearSphere`, and `$geoNear` are not accepted here — use `$geoWithin` instead. |
+
+All four string-valued field names — `connectFromField`, `connectToField`, `as`, and `depthField` — reject names beginning with `$`. Note that `startWith` is an *expression*, so `startWith: "$reportsTo"` is correct while `connectFromField: "$reportsTo"` is a parse error.
 
 Any other parameter is rejected with `Unrecognized parameter supplied to stage $graphlookup`.
 
@@ -91,7 +93,7 @@ This query returns the following result:
 ]
 ```
 
-One pipeline reaches every ancestor. The order of the `as` array is not defined — use `depthField` when you need to know how far away each match was.
+One pipeline reaches every ancestor. Each matched document appears in the `as` array exactly once, at the lowest depth it was reached from — a document reachable by two paths is not duplicated. DocumentDB currently emits the array in `_id` order, which is what the outputs on this page show; that ordering is not part of the operator's contract, so add an explicit `$sort` if your application depends on it, and use `depthField` when you need to know how far away each match was.
 
 ### Example 2: Bounding the search and recording depth
 
@@ -192,9 +194,27 @@ Ana is reachable but her title is `VP, Retail`, so she is filtered out — and b
 | `as` missing | `$graphLookup requires 'as' field to be specified` |
 | `startWith` missing | `You must provide a 'startWith' parameter when performing a $graphLookup operation` |
 | Unknown parameter | `Unrecognized parameter supplied to stage $graphlookup: <name>` |
-| Negative `maxDepth` | `The value of graphlookup.maxDepth must always be a non-negative integer number.` |
+| Negative `maxDepth` | `The value of graphlookup.maxDepth must always be a non‑negative integer number.` |
+| `as` begins with `$` | `'as' field name cannot begin with '$'` |
+| `connectFromField` begins with `$` | `FieldPath field names cannot begin with symbol such as '$'` |
+| `connectToField` begins with `$` | `connectToField: FieldPath field names cannot begin with the symbol '$'` |
+| `depthField` begins with `$` | `depthField:FieldPath field names cannot begin with the symbol '$'` |
+| `from` is a sharded collection | `$graphLookup using 'from' on a sharded collection is currently unsupported` |
+| `restrictSearchWithMatch` uses a proximity operator | `$near, $nearSphere and $geoNear cannot be used here. Use $geoWithin instead.` |
+
+The `maxDepth` message contains a non-breaking hyphen (U+2011) rather than an ASCII hyphen, so a literal string match against `non-negative` will not find it.
+
+## Limitations
+
+**`from` cannot be a sharded collection.** The traversal is refused before it begins:
+
+```
+$graphLookup using 'from' on a sharded collection is currently unsupported
+```
+
+The collection the pipeline runs *against* may be sharded; the restriction applies only to the collection named by `from`. Every example on this page uses `employees` in both roles, so sharding `employees` would stop all of them.
 
 ## Related
 
-- [`$lookup`](../%24lookup/) — joins a single level instead of recursing.
-- [`$unwind`](../%24unwind/) — flattens the array produced in the `as` field.
+- [`$lookup`](./%24lookup.md) — joins a single level instead of recursing.
+- [`$unwind`](./%24unwind.md) — flattens the array produced in the `as` field.

--- a/api-reference/operators/aggregation/$graphlookup.md
+++ b/api-reference/operators/aggregation/$graphlookup.md
@@ -185,6 +185,16 @@ This query returns the following result:
 
 Ana is reachable but her title is `VP, Retail`, so she is filtered out — and because the traversal cannot pass through an excluded document, anyone above her would be unreachable as well.
 
+## Limitations
+
+**`from` cannot be a sharded collection.** The traversal is refused before it begins:
+
+```
+$graphLookup using 'from' on a sharded collection is currently unsupported
+```
+
+The collection the pipeline runs *against* may be sharded; the restriction applies only to the collection named by `from`. Every example on this page uses `employees` in both roles, so sharding `employees` would stop all of them.
+
 ## Error cases
 
 | Problem | Error |
@@ -203,16 +213,6 @@ Ana is reachable but her title is `VP, Retail`, so she is filtered out — and b
 | `restrictSearchWithMatch` uses a proximity operator | `$near, $nearSphere and $geoNear cannot be used here. Use $geoWithin instead.` |
 
 The `maxDepth` message contains a non-breaking hyphen (U+2011) rather than an ASCII hyphen, so a literal string match against `non-negative` will not find it.
-
-## Limitations
-
-**`from` cannot be a sharded collection.** The traversal is refused before it begins:
-
-```
-$graphLookup using 'from' on a sharded collection is currently unsupported
-```
-
-The collection the pipeline runs *against* may be sharded; the restriction applies only to the collection named by `from`. Every example on this page uses `employees` in both roles, so sharding `employees` would stop all of them.
 
 ## Related
 

--- a/api-reference/operators/aggregation/$limit.md
+++ b/api-reference/operators/aggregation/$limit.md
@@ -98,7 +98,19 @@ Without a preceding `$sort`, which document survives is not guaranteed.
 
 ## Behavior
 
-When a pipeline contains more than one `$limit`, the smallest value wins — a `$limit: 10` followed later by `$limit: 3` yields at most three documents.
+Each `$limit` applies to the output of the stages before it. When two `$limit` stages are adjacent, the effect is the smaller of the two — `[{ $limit: 10 }, { $limit: 3 }]` yields at most three documents.
+
+That shortcut does not generalize across stages that can produce more documents than they consume. In the pipeline below, the first `$limit` caps the input at three documents, `$unwind` expands them, and the second `$limit` caps the expanded rows — so the result can be up to ten documents, not three:
+
+```javascript
+db.stores.aggregate([
+  { $limit: 3 },
+  { $unwind: "$promotionEvents" },
+  { $limit: 10 }
+])
+```
+
+`$lookup` followed by `$unwind`, and `$unionWith`, behave the same way.
 
 ## Error cases
 
@@ -112,5 +124,5 @@ A value that cannot be represented as a 64-bit integer is also rejected.
 
 ## Related
 
-- [`$skip`](../%24skip/) — skips documents instead of truncating the result.
-- [`$sort`](../%24sort/) — order documents before limiting them.
+- [`$skip`](./%24skip.md) — skips documents instead of truncating the result.
+- [`$sort`](./%24sort.md) — order documents before limiting them.

--- a/api-reference/operators/aggregation/$limit.md
+++ b/api-reference/operators/aggregation/$limit.md
@@ -1,0 +1,116 @@
+---
+title: $limit
+description: The $limit stage in the aggregation pipeline restricts the number of documents passed to the next stage.
+type: operators
+category: aggregation
+---
+
+# $limit
+
+The `$limit` stage in the aggregation pipeline restricts the number of documents passed on to the next stage. It is most often combined with `$sort` to return a top-N result, or placed after `$match` to cap the amount of work later stages do.
+
+## Syntax
+
+```javascript
+{
+  $limit: <positiveInteger>
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`positiveInteger`** | The maximum number of documents to pass to the next stage. Must be a number that can be represented as a 64-bit integer, and must be greater than zero. |
+
+## Examples
+
+The examples on this page use the following documents in the `stores` collection.
+
+```json
+[
+  {
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "sales": { "totalSales": 75670 }
+  },
+  {
+    "_id": "2e2f4c9e-6a1c-4a3a-9b52-7f1a5d0c2f11",
+    "name": "Fourth Coffee | Beverage Shop - Lake Ellenmouth",
+    "sales": { "totalSales": 21200 }
+  },
+  {
+    "_id": "9d2c1a77-8f52-4a1e-9a55-3d4e6b8c0a22",
+    "name": "Contoso | Beverage Shop - Port Alina",
+    "sales": { "totalSales": 112400 }
+  }
+]
+```
+
+### Example 1: Returning the top results
+
+This query sorts stores by total sales and returns only the two highest.
+
+```javascript
+db.stores.aggregate([
+  { $sort: { "sales.totalSales": -1 } },
+  { $project: { _id: 0, name: 1, "sales.totalSales": 1 } },
+  { $limit: 2 }
+])
+```
+
+This query returns the following result:
+
+```json
+[
+  {
+    "name": "Contoso | Beverage Shop - Port Alina",
+    "sales": { "totalSales": 112400 }
+  },
+  {
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "sales": { "totalSales": 75670 }
+  }
+]
+```
+
+Place `$limit` *after* `$sort` when you want a top-N result. A `$limit` that runs before `$sort` truncates the input first, so the sort only orders the documents that survived.
+
+### Example 2: Limiting to a single document
+
+```javascript
+db.stores.aggregate([
+  { $match: { "sales.totalSales": { $gt: 50000 } } },
+  { $limit: 1 },
+  { $project: { _id: 0, name: 1 } }
+])
+```
+
+This query returns the following result:
+
+```json
+[
+  { "name": "First Up Consultants | Beverage Shop - Satterfieldmouth" }
+]
+```
+
+Without a preceding `$sort`, which document survives is not guaranteed.
+
+## Behavior
+
+When a pipeline contains more than one `$limit`, the smallest value wins — a `$limit: 10` followed later by `$limit: 3` yields at most three documents.
+
+## Error cases
+
+| Specification | Error |
+| --- | --- |
+| `{ $limit: 0 }` | `The specified limit value must always be positive` |
+| `{ $limit: -1 }` | `Invalid argument passed to the $skip stage: a non-negative number was expected but received in $limit: -1` |
+| `{ $limit: "2" }` | `the limit must be specified as a number` |
+
+A value that cannot be represented as a 64-bit integer is also rejected.
+
+## Related
+
+- [`$skip`](../%24skip/) — skips documents instead of truncating the result.
+- [`$sort`](../%24sort/) — order documents before limiting them.

--- a/api-reference/operators/aggregation/$project.md
+++ b/api-reference/operators/aggregation/$project.md
@@ -48,9 +48,23 @@ The examples on this page use the following document from the `stores` collectio
       { "categoryName": "Rum", "totalSales": 1734 }
     ]
   },
-  "tags": ["Wine", "Bitters"]
+  "promotionEvents": [
+    {
+      "eventName": "Unbeatable Bargain Bash",
+      "promotionalDates": {
+        "startDate": { "Year": 2024, "Month": 6, "Day": 23 },
+        "endDate": { "Year": 2024, "Month": 7, "Day": 2 }
+      },
+      "discounts": [
+        { "categoryName": "Whiskey", "discountPercentage": 7 },
+        { "categoryName": "Bitters", "discountPercentage": 15 }
+      ]
+    }
+  ]
 }
 ```
+
+The `promotionEvents` array is shown abbreviated — the full document carries several events, each with its own list of discounts.
 
 ### Example 1: Including specific fields
 
@@ -110,7 +124,7 @@ When every field in the specification is set to `0`, the stage is an exclusion p
 
 ```javascript
 db.stores.aggregate([
-  { $project: { sales: 0, staff: 0, location: 0, tags: 0 } }
+  { $project: { sales: 0, staff: 0, location: 0, promotionEvents: 0 } }
 ])
 ```
 
@@ -127,16 +141,34 @@ This query returns the following result:
 
 ## Behavior
 
-**`_id` is included by default.** It is the only field you can exclude from an inclusion projection; suppress it with `_id: 0`. Using `{ $project: { _id: 0 } }` on its own is a pure exclusion and keeps every other field.
+**`_id` is included by default.** It is the only field you can suppress with `0` or `false` inside an inclusion projection. Using `{ $project: { _id: 0 } }` on its own is a pure exclusion and keeps every other field.
+
+The exemption applies to **top-level `_id` only**. A nested `_id` behaves like any other field, so this fails:
+
+```javascript
+db.stores.aggregate([{ $project: { name: 1, sales: { _id: 0 } } }])
+```
+
+```
+exclusion cannot be applied to field _id within the inclusion projection.
+```
+
+**`$$REMOVE` drops any field from an inclusion projection.** Assigning `$$REMOVE` to a field is an expression rather than an exclusion, so it does not trip the mixing rule and the field is absent from the output:
+
+```javascript
+db.stores.aggregate([{ $project: { name: 1, location: "$$REMOVE" } }])
+```
+
+This is what makes conditional suppression possible — `{ $cond: [<test>, "$field", "$$REMOVE"] }` keeps a field only when the test passes.
 
 **Inclusion and exclusion cannot be mixed.** Apart from top-level `_id`, a single `$project` is either an inclusion projection or an exclusion projection. Mixing them fails:
 
 ```javascript
-db.stores.aggregate([{ $project: { name: 1, tags: 0 } }])
+db.stores.aggregate([{ $project: { name: 1, location: 0 } }])
 ```
 
 ```
-exclusion cannot be applied to field tags within the inclusion projection.
+exclusion cannot be applied to field location within the inclusion projection.
 ```
 
 **Field names cannot begin with `$`.** A literal field name starting with `$` is rejected — use `$getField` or `$setField` for such fields:
@@ -145,10 +177,13 @@ exclusion cannot be applied to field tags within the inclusion projection.
 FieldPath field names cannot begin with the operators symbol '$'; you might want to use $getField or $setField instead.
 ```
 
+The DBRef field names `$id`, `$ref`, and `$db` are exempt, so `{ $project: { "$id": 1 } }` is accepted and projects DBRef-shaped documents directly.
+
 **An empty specification is accepted.** `{ $project: {} }` passes documents through unchanged rather than raising an error.
 
 ## Related
 
-- [`$addFields`](../%24addfields/) — adds fields while keeping all existing ones.
-- [`$set`](../%24set/) — alias for `$addFields`.
-- [`$unset`](../%24unset/) — removes fields without switching the whole stage to exclusion semantics.
+- [`$addFields`](./%24addfields.md) — adds fields while keeping all existing ones.
+- [`$set`](./%24set.md) — alias for `$addFields`.
+- [`$unset`](./%24unset.md) — removes fields without switching the whole stage to exclusion semantics.
+- [`$meta`](../projection/%24meta.md) — surface search metadata, such as a `$vectorSearch` similarity score, as a projected field.

--- a/api-reference/operators/aggregation/$project.md
+++ b/api-reference/operators/aggregation/$project.md
@@ -1,0 +1,154 @@
+---
+title: $project
+description: The $project stage in the aggregation pipeline reshapes documents by including, excluding, or computing fields.
+type: operators
+category: aggregation
+---
+
+# $project
+
+The `$project` stage in the aggregation pipeline reshapes each document that passes through it. Use it to include only the fields you need, remove fields you do not, rename fields, or add fields computed from existing values.
+
+## Syntax
+
+```javascript
+{
+  $project: {
+    <field1>: <1 | true | 0 | false | expression>,
+    <field2>: <1 | true | 0 | false | expression>,
+    ...
+  }
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`field`** | The name of a field to include, exclude, or compute. Dotted paths such as `sales.totalSales` address nested fields. |
+| **`1` or `true`** | Includes the field in the output document. |
+| **`0` or `false`** | Excludes the field from the output document. |
+| **`expression`** | An aggregation expression whose result becomes the value of the field. Adding a computed field counts as an inclusion. |
+
+## Examples
+
+The examples on this page use the following document from the `stores` collection.
+
+```json
+{
+  "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+  "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+  "location": { "lat": -89.2384, "lon": -46.4012 },
+  "staff": { "totalStaff": { "fullTime": 8, "partTime": 20 } },
+  "sales": {
+    "totalSales": 75670,
+    "salesByCategory": [
+      { "categoryName": "Wine Accessories", "totalSales": 34440 },
+      { "categoryName": "Bitters", "totalSales": 39496 },
+      { "categoryName": "Rum", "totalSales": 1734 }
+    ]
+  },
+  "tags": ["Wine", "Bitters"]
+}
+```
+
+### Example 1: Including specific fields
+
+This query keeps only the store name and its total sales, and suppresses `_id`.
+
+```javascript
+db.stores.aggregate([
+  { $project: { _id: 0, name: 1, "sales.totalSales": 1 } }
+])
+```
+
+This query returns the following result:
+
+```json
+[
+  {
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "sales": { "totalSales": 75670 }
+  }
+]
+```
+
+Projecting a dotted path preserves the surrounding structure — `sales.totalSales` comes back nested inside `sales`, not flattened.
+
+### Example 2: Adding a computed field
+
+This query returns the store name alongside a headcount computed from the two staff fields.
+
+```javascript
+db.stores.aggregate([
+  {
+    $project: {
+      _id: 0,
+      name: 1,
+      totalStaff: {
+        $add: ["$staff.totalStaff.fullTime", "$staff.totalStaff.partTime"]
+      }
+    }
+  }
+])
+```
+
+This query returns the following result:
+
+```json
+[
+  {
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth",
+    "totalStaff": 28
+  }
+]
+```
+
+### Example 3: Excluding fields
+
+When every field in the specification is set to `0`, the stage is an exclusion projection: every field except the listed ones is kept.
+
+```javascript
+db.stores.aggregate([
+  { $project: { sales: 0, staff: 0, location: 0, tags: 0 } }
+])
+```
+
+This query returns the following result:
+
+```json
+[
+  {
+    "_id": "0fcc0bf0-ed18-4ab8-b558-9848e18058f4",
+    "name": "First Up Consultants | Beverage Shop - Satterfieldmouth"
+  }
+]
+```
+
+## Behavior
+
+**`_id` is included by default.** It is the only field you can exclude from an inclusion projection; suppress it with `_id: 0`. Using `{ $project: { _id: 0 } }` on its own is a pure exclusion and keeps every other field.
+
+**Inclusion and exclusion cannot be mixed.** Apart from top-level `_id`, a single `$project` is either an inclusion projection or an exclusion projection. Mixing them fails:
+
+```javascript
+db.stores.aggregate([{ $project: { name: 1, tags: 0 } }])
+```
+
+```
+exclusion cannot be applied to field tags within the inclusion projection.
+```
+
+**Field names cannot begin with `$`.** A literal field name starting with `$` is rejected — use `$getField` or `$setField` for such fields:
+
+```
+FieldPath field names cannot begin with the operators symbol '$'; you might want to use $getField or $setField instead.
+```
+
+**An empty specification is accepted.** `{ $project: {} }` passes documents through unchanged rather than raising an error.
+
+## Related
+
+- [`$addFields`](../%24addfields/) — adds fields while keeping all existing ones.
+- [`$set`](../%24set/) — alias for `$addFields`.
+- [`$unset`](../%24unset/) — removes fields without switching the whole stage to exclusion semantics.

--- a/api-reference/operators/aggregation/$vectorsearch.md
+++ b/api-reference/operators/aggregation/$vectorsearch.md
@@ -29,13 +29,21 @@ The `$vectorSearch` stage in the aggregation pipeline runs an approximate neares
 
 | Parameter | Description |
 | --- | --- |
-| **`queryVector`** | Required. The query embedding, as an array of numbers. Cannot be empty, and cannot be longer than 16000 elements. Its length must match the `dimensions` of the index. |
+| **`queryVector`** | Required. The query embedding, as an array of numbers. Cannot be empty, and cannot be longer than 16000 elements. Its length must match the `dimensions` of the index — which is itself capped well below 16000 unless the index sets `compression`. See [Creating the vector index](#creating-the-vector-index). |
 | **`path`** | Required. The document field holding the stored embedding. Must be covered by a vector index. |
-| **`limit`** | Required. The number of documents to return. Must be a positive 32-bit integer. |
-| **`numCandidates`** | Optional. For HNSW indexes, the size of the candidate list explored during the search (`efSearch`). An integer between 1 and 1000; larger values improve recall at the cost of latency. When omitted, DocumentDB chooses a default from the index's `efConstruction` and the size of the collection. |
-| **`filter`** | Optional. A query document applied as a pre-filter, so only matching documents are considered. Every field used in the filter must itself be indexed. |
+| **`limit`** | Required. The number of documents to return. Must be a BSON 32-bit integer greater than zero. |
+| **`numCandidates`** | Optional. For HNSW indexes, the size of the candidate list explored during the search (`efSearch`). Must be a BSON 32-bit integer between 1 and 1000; larger values improve recall at the cost of latency. **Ignored on `vector-ivf` indexes** — no error is raised and the query behaves as if it were omitted. When omitted, DocumentDB derives a default; see [Choosing numCandidates](#choosing-numcandidates). |
+| **`filter`** | Optional. A query document intersected with the vector search, so only matching documents are returned. Every field used in the filter must itself be indexed, and `filter` is **not supported on sharded collections**. See [Example 3](#example-3-restricting-the-search-with-a-filter). |
 
 Any other field is rejected with `BSON field '$vectorSearch.<name>' is an unknown field`.
+
+`limit` and `numCandidates` are checked for the BSON int32 wire type with no numeric coercion, so a double or a 64-bit integer is rejected even when its value is in range:
+
+```
+The BSON field 'limit' has an incorrect type 'long'; it should be of type 'int'.
+```
+
+This matters for drivers that marshal bare integer literals as doubles, and for explicit `NumberLong(...)` values. Note that the index options below (`dimensions`, `m`, `efConstruction`, `numLists`) *do* accept any numeric type — the same literal can be valid in one block and fatal in the other.
 
 ## Examples
 
@@ -74,7 +82,56 @@ db.runCommand({
 })
 ```
 
-`kind` accepts `vector-hnsw` and `vector-ivf`. `similarity` selects the distance metric — `COS` for cosine, `L2` for Euclidean, `IP` for inner product. `dimensions` must match the length of the vectors you store and query.
+`kind` and `similarity` are both required. `similarity` selects the distance metric — `COS` for cosine, `L2` for Euclidean, `IP` for inner product. `dimensions` must match the length of the vectors you store and query, and must be greater than 1.
+
+**`dimensions` is capped by `compression`, not by the 16000 query-vector limit.** An uncompressed index tops out at 2000:
+
+| `compression` | Maximum `dimensions` |
+| --- | --- |
+| omitted (uncompressed) | 2000 |
+| `"half"` | 4000 |
+| `"pq"` | 16000 |
+
+Exceeding the cap fails index creation with `field cannot have more than 2000 dimensions for vector index`. This is the limit you hit first with common embedding models — `text-embedding-3-large` produces 3072 dimensions, which needs `compression: "half"` or `"pq"`. Both compression modes are gated behind server configuration and `half` additionally requires a pgvector build with half-vector support, so they may be unavailable on a given deployment:
+
+```
+Compression type 'half' is not enabled.
+The compression type 'half' is currently unsupported.
+```
+
+**Tuning options are index-kind specific**, and the two HNSW options are coupled:
+
+| Option | Kind | Range | Default |
+| --- | --- | --- | --- |
+| `m` | `vector-hnsw` | 2 – 100 | 16 |
+| `efConstruction` | `vector-hnsw` | 4 – 1000 | 64 |
+| `numLists` | `vector-ivf` | 1 – 32768 | 100 |
+
+`efConstruction` must be at least `2 * m`, otherwise index creation fails:
+
+```
+efConstruction must be greater than or equal to 2 * m for vector-hnsw indexes
+```
+
+The example above uses `m: 16` with `efConstruction: 64`, which satisfies the rule — raising `m` to 48 without also raising `efConstruction` does not.
+
+An IVF index is created the same way, with `numLists` in place of the HNSW options:
+
+```javascript
+db.runCommand({
+  createIndexes: "products",
+  indexes: [{
+    key: { embedding: "cosmosSearch" },
+    name: "embedding_ivf_idx",
+    cosmosSearchOptions: {
+      kind: "vector-ivf",
+      similarity: "COS",
+      dimensions: 3,
+      numLists: 100
+    }
+  }]
+})
+```
 
 ### Example 1: Finding the nearest documents
 
@@ -105,9 +162,25 @@ This query returns the following result:
 
 Results come back ordered from nearest to furthest.
 
+The `$project` here is doing more than trimming output. `$vectorSearch` attaches an internal `__cosmos_meta__` field to every document it returns, so the same pipeline without a projection gives you:
+
+```json
+[
+  {
+    "_id": 1,
+    "name": "Espresso Machine",
+    "category": "appliance",
+    "embedding": [0.9, 0.1, 0.05],
+    "__cosmos_meta__": { "score": 1 }
+  }
+]
+```
+
+An *exclusion* projection such as `{ $project: { embedding: 0 } }` does not remove `__cosmos_meta__` — only an inclusion projection that omits it, as above, will. Read the score through `$meta` rather than by reaching into this field, and take care not to write documents straight back into a collection without stripping it.
+
 ### Example 2: Returning the similarity score
 
-The score assigned by the search is available to later stages through `$meta: "searchScore"`.
+The score assigned by the search is available to later stages through `$meta: "searchScore"`. `$meta: "vectorSearchScore"` is accepted as an equivalent alias — it is the keyword MongoDB Atlas uses for `$vectorSearch`, so pipelines ported from Atlas work unchanged.
 
 ```javascript
 db.products.aggregate([
@@ -133,7 +206,15 @@ This query returns the following result:
 
 ### Example 3: Restricting the search with a filter
 
-`filter` narrows the candidate set before the vector comparison, so `limit` counts only documents that satisfy it.
+`filter` restricts results to documents matching a query document. DocumentDB runs the approximate nearest-neighbor scan and the filter query separately and intersects them, then applies `limit` to the intersection — so every returned document satisfies the filter, but **reaching `limit` is best-effort**: it depends on how many matching documents the ANN scan encounters before it stops.
+
+The practical consequence is that a highly selective filter over a large collection can return fewer documents than `limit`, with no error and nothing to distinguish it from there genuinely being no more matches. On a million-document collection, `filter: { category: "wine" }` matching 0.1% of documents with `limit: 10` may return only a handful of rows. Raising `numCandidates` widens the scan and is the remedy. How far the scan can extend also depends on the deployed pgvector version — iterative scanning requires pgvector 0.8.0 or later and is silently skipped below that, which makes short results considerably more likely.
+
+**`filter` is not supported on sharded collections.** The query is rejected outright, even though unfiltered `$vectorSearch` continues to work on the same collection:
+
+```
+Filter is not supported for vector search on sharded collection.
+```
 
 **Every field used in `filter` must be indexed.** Index the filter path first:
 
@@ -181,7 +262,7 @@ db.products.aggregate([
       queryVector: [0.1, 0.88, 0.2],
       path: "embedding",
       limit: 2,
-      numCandidates: 40
+      numCandidates: 200
     }
   },
   { $project: { _id: 0, name: 1, category: 1 } }
@@ -197,7 +278,20 @@ This query returns the following result:
 ]
 ```
 
-Raise `numCandidates` when a search misses documents you expect it to find; the search explores a larger neighborhood before selecting the top `limit` results.
+Raise `numCandidates` when a search misses documents you expect it to find; the search explores a larger neighborhood before selecting the top `limit` results. The five-document collection used here is small enough that the search is exhaustive at any setting, so the value above changes nothing — `numCandidates` only begins to matter once the index is large enough that the HNSW graph is traversed rather than scanned.
+
+### Choosing numCandidates
+
+When `numCandidates` is omitted on an HNSW index, the default depends on the size of the collection, with a hard threshold at 10,000 rows:
+
+| Rows in the collection | Default `efSearch` |
+| --- | --- |
+| fewer than 10,000 | the index's `efConstruction` |
+| 10,000 or more | 40 |
+
+Above the threshold, `efConstruction` stops feeding the default entirely. An index built with `efConstruction: 512` for high recall searches at `efSearch: 40` on a 50,000-document collection unless `numCandidates` is set explicitly — a large drop from the configured value, which surfaces only as missing results. Set `numCandidates` by hand on any production-sized collection.
+
+On `vector-ivf` indexes `numCandidates` has no effect at all. It is accepted and validated, but the IVF search path reads only `nProbes`, which `$vectorSearch` does not expose — so there is no recall knob for IVF in this stage, and raising `numCandidates` returns byte-identical results.
 
 ## Error cases
 
@@ -207,17 +301,31 @@ Raise `numCandidates` when a search misses documents you expect it to find; the 
 | `limit` is zero or negative | `$vectorSearch.limit must be provided as a positive integer value.` |
 | `queryVector` is empty | `$vectorSearch.queryVector cannot be an empty array.` |
 | `queryVector` is not an array of numbers | `$vectorSearch.queryVector must be an array of numbers.` |
+| `queryVector` longer than 16000 elements | `Length of the query vector cannot exceed 16000` |
 | `queryVector` length does not match the index | `expected <n> dimensions, not <m>` |
+| `numCandidates` below 1 | `The vectorSearch.numCandidates should have a value that is not less than 1.` |
 | `numCandidates` above 1000 | `$vectorSearch.numCandidates must be less than or equal to 1000.` |
+| `limit` or `numCandidates` is not a BSON int32 | `The BSON field 'limit' has an incorrect type 'long'; it should be of type 'int'.` |
+| `$vectorSearch` is not the first stage | `The $vectorSearch needs to appear as the initial stage in the processing pipeline.` |
 | No vector index on `path` | `Similarity index was not found for a vector similarity search query.` |
 | Unindexed field in `filter` | `The index for filter path '<field>' was not found, please check whether the index is created.` |
+| `filter` on a sharded collection | `Filter is not supported for vector search on sharded collection.` |
 | Unknown field | `BSON field '$vectorSearch.<name>' is an unknown field` |
+
+The `numCandidates` lower-bound message omits the `$` prefix that the upper-bound message carries; both are reproduced above as the server emits them. Note also that `numCandidates: 0` is an error rather than a request for the default.
+
+The first-stage check is stricter than it reads: it also rejects the stage when it runs against a view, or nested inside `$facet` or `$lookup`, even where `$vectorSearch` is demonstrably the first stage of that pipeline.
+
+`expected <n> dimensions, not <m>` is raised by pgvector rather than by DocumentDB, so its exact wording can change with a pgvector upgrade.
 
 ## Notes
 
 An `index` field is accepted for compatibility but currently ignored — the search uses the vector index defined on `path`.
 
+Documents returned by `$vectorSearch` carry an internal `__cosmos_meta__` field holding the similarity score. It is not removed by an exclusion projection — use an inclusion `$project`, and read the score with `$meta: "searchScore"` rather than from the field directly.
+
 ## Related
 
-- [`$limit`](../%24limit/) — `$vectorSearch` takes its own `limit`; a later `$limit` can narrow the result further.
-- [`$project`](../%24project/) — shape the results, and surface the similarity score with `$meta`.
+- [`$limit`](./%24limit.md) — `$vectorSearch` takes its own `limit`; a later `$limit` can narrow the result further.
+- [`$project`](./%24project.md) — shape the results, and surface the similarity score with `$meta`.
+- [`$meta`](../projection/%24meta.md) — the metadata operator used to project `searchScore`.

--- a/api-reference/operators/aggregation/$vectorsearch.md
+++ b/api-reference/operators/aggregation/$vectorsearch.md
@@ -280,7 +280,7 @@ This query returns the following result:
 
 Raise `numCandidates` when a search misses documents you expect it to find; the search explores a larger neighborhood before selecting the top `limit` results. The five-document collection used here is small enough that the search is exhaustive at any setting, so the value above changes nothing — `numCandidates` only begins to matter once the index is large enough that the HNSW graph is traversed rather than scanned.
 
-### Choosing numCandidates
+## Choosing numCandidates
 
 When `numCandidates` is omitted on an HNSW index, the default depends on the size of the collection, with a hard threshold at 10,000 rows:
 

--- a/api-reference/operators/aggregation/$vectorsearch.md
+++ b/api-reference/operators/aggregation/$vectorsearch.md
@@ -207,6 +207,7 @@ Raise `numCandidates` when a search misses documents you expect it to find; the 
 | `limit` is zero or negative | `$vectorSearch.limit must be provided as a positive integer value.` |
 | `queryVector` is empty | `$vectorSearch.queryVector cannot be an empty array.` |
 | `queryVector` is not an array of numbers | `$vectorSearch.queryVector must be an array of numbers.` |
+| `queryVector` length does not match the index | `expected <n> dimensions, not <m>` |
 | `numCandidates` above 1000 | `$vectorSearch.numCandidates must be less than or equal to 1000.` |
 | No vector index on `path` | `Similarity index was not found for a vector similarity search query.` |
 | Unindexed field in `filter` | `The index for filter path '<field>' was not found, please check whether the index is created.` |

--- a/api-reference/operators/aggregation/$vectorsearch.md
+++ b/api-reference/operators/aggregation/$vectorsearch.md
@@ -1,0 +1,222 @@
+---
+title: $vectorSearch
+description: The $vectorSearch stage in the aggregation pipeline runs an approximate nearest-neighbor search over a vector index.
+type: operators
+category: aggregation
+---
+
+# $vectorSearch
+
+The `$vectorSearch` stage in the aggregation pipeline runs an approximate nearest-neighbor search over a vector index and returns the documents whose stored embedding is closest to a query vector. It lets you keep documents and their embeddings in one database — semantic search, retrieval-augmented generation, and recommendations run as an ordinary aggregation pipeline, with the results available to every stage that follows.
+
+`$vectorSearch` must be the first stage in the pipeline, and the field named by `path` must be covered by a vector index.
+
+## Syntax
+
+```javascript
+{
+  $vectorSearch: {
+    queryVector: [<number>, ...],
+    path: <string>,
+    limit: <positiveInteger>,
+    numCandidates: <integer>,
+    filter: <document>
+  }
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`queryVector`** | Required. The query embedding, as an array of numbers. Cannot be empty, and cannot be longer than 16000 elements. Its length must match the `dimensions` of the index. |
+| **`path`** | Required. The document field holding the stored embedding. Must be covered by a vector index. |
+| **`limit`** | Required. The number of documents to return. Must be a positive 32-bit integer. |
+| **`numCandidates`** | Optional. For HNSW indexes, the size of the candidate list explored during the search (`efSearch`). An integer between 1 and 1000; larger values improve recall at the cost of latency. When omitted, DocumentDB chooses a default from the index's `efConstruction` and the size of the collection. |
+| **`filter`** | Optional. A query document applied as a pre-filter, so only matching documents are considered. Every field used in the filter must itself be indexed. |
+
+Any other field is rejected with `BSON field '$vectorSearch.<name>' is an unknown field`.
+
+## Examples
+
+The examples on this page use the following documents in a `products` collection.
+
+```json
+[
+  { "_id": 1, "name": "Espresso Machine", "category": "appliance", "embedding": [0.9, 0.1, 0.05] },
+  { "_id": 2, "name": "Coffee Grinder", "category": "appliance", "embedding": [0.85, 0.15, 0.1] },
+  { "_id": 3, "name": "Merlot Bottle", "category": "wine", "embedding": [0.05, 0.9, 0.2] },
+  { "_id": 4, "name": "Chardonnay Bottle", "category": "wine", "embedding": [0.1, 0.85, 0.25] },
+  { "_id": 5, "name": "Whiskey Tumbler", "category": "glassware", "embedding": [0.2, 0.3, 0.9] }
+]
+```
+
+Three-element vectors keep the examples readable; real embeddings are typically hundreds or thousands of elements.
+
+### Creating the vector index
+
+`$vectorSearch` requires an index on the embedding field. Create one with `createIndexes` using the `cosmosSearch` index type:
+
+```javascript
+db.runCommand({
+  createIndexes: "products",
+  indexes: [{
+    key: { embedding: "cosmosSearch" },
+    name: "embedding_hnsw_idx",
+    cosmosSearchOptions: {
+      kind: "vector-hnsw",
+      similarity: "COS",
+      dimensions: 3,
+      m: 16,
+      efConstruction: 64
+    }
+  }]
+})
+```
+
+`kind` accepts `vector-hnsw` and `vector-ivf`. `similarity` selects the distance metric — `COS` for cosine, `L2` for Euclidean, `IP` for inner product. `dimensions` must match the length of the vectors you store and query.
+
+### Example 1: Finding the nearest documents
+
+This query returns the three products closest to the query vector.
+
+```javascript
+db.products.aggregate([
+  {
+    $vectorSearch: {
+      queryVector: [0.9, 0.1, 0.05],
+      path: "embedding",
+      limit: 3
+    }
+  },
+  { $project: { _id: 0, name: 1, category: 1 } }
+])
+```
+
+This query returns the following result:
+
+```json
+[
+  { "name": "Espresso Machine", "category": "appliance" },
+  { "name": "Coffee Grinder", "category": "appliance" },
+  { "name": "Whiskey Tumbler", "category": "glassware" }
+]
+```
+
+Results come back ordered from nearest to furthest.
+
+### Example 2: Returning the similarity score
+
+The score assigned by the search is available to later stages through `$meta: "searchScore"`.
+
+```javascript
+db.products.aggregate([
+  {
+    $vectorSearch: {
+      queryVector: [0.9, 0.1, 0.05],
+      path: "embedding",
+      limit: 2
+    }
+  },
+  { $project: { _id: 0, name: 1, score: { $meta: "searchScore" } } }
+])
+```
+
+This query returns the following result:
+
+```json
+[
+  { "name": "Espresso Machine", "score": 1 },
+  { "name": "Coffee Grinder", "score": 0.9961580039320722 }
+]
+```
+
+### Example 3: Restricting the search with a filter
+
+`filter` narrows the candidate set before the vector comparison, so `limit` counts only documents that satisfy it.
+
+**Every field used in `filter` must be indexed.** Index the filter path first:
+
+```javascript
+db.products.createIndex({ category: 1 }, { name: "category_idx" })
+```
+
+Then filter on it:
+
+```javascript
+db.products.aggregate([
+  {
+    $vectorSearch: {
+      queryVector: [0.9, 0.1, 0.05],
+      path: "embedding",
+      limit: 2,
+      filter: { category: "wine" }
+    }
+  },
+  { $project: { _id: 0, name: 1, category: 1 } }
+])
+```
+
+This query returns the following result:
+
+```json
+[
+  { "name": "Chardonnay Bottle", "category": "wine" },
+  { "name": "Merlot Bottle", "category": "wine" }
+]
+```
+
+Without that index the same query fails:
+
+```
+The index for filter path 'category' was not found, please check whether the index is created.
+```
+
+### Example 4: Tuning recall with numCandidates
+
+```javascript
+db.products.aggregate([
+  {
+    $vectorSearch: {
+      queryVector: [0.1, 0.88, 0.2],
+      path: "embedding",
+      limit: 2,
+      numCandidates: 40
+    }
+  },
+  { $project: { _id: 0, name: 1, category: 1 } }
+])
+```
+
+This query returns the following result:
+
+```json
+[
+  { "name": "Merlot Bottle", "category": "wine" },
+  { "name": "Chardonnay Bottle", "category": "wine" }
+]
+```
+
+Raise `numCandidates` when a search misses documents you expect it to find; the search explores a larger neighborhood before selecting the top `limit` results.
+
+## Error cases
+
+| Problem | Error |
+| --- | --- |
+| `path`, `queryVector`, or `limit` missing | `$path, $queryVector, and $limit are all required fields for using a vector index.` |
+| `limit` is zero or negative | `$vectorSearch.limit must be provided as a positive integer value.` |
+| `queryVector` is empty | `$vectorSearch.queryVector cannot be an empty array.` |
+| `queryVector` is not an array of numbers | `$vectorSearch.queryVector must be an array of numbers.` |
+| `numCandidates` above 1000 | `$vectorSearch.numCandidates must be less than or equal to 1000.` |
+| No vector index on `path` | `Similarity index was not found for a vector similarity search query.` |
+| Unindexed field in `filter` | `The index for filter path '<field>' was not found, please check whether the index is created.` |
+| Unknown field | `BSON field '$vectorSearch.<name>' is an unknown field` |
+
+## Notes
+
+An `index` field is accepted for compatibility but currently ignored — the search uses the vector index defined on `path`.
+
+## Related
+
+- [`$limit`](../%24limit/) — `$vectorSearch` takes its own `limit`; a later `$limit` can narrow the result further.
+- [`$project`](../%24project/) — shape the results, and surface the similarity score with `$meta`.

--- a/api-reference/operators/projection/$meta.md
+++ b/api-reference/operators/projection/$meta.md
@@ -30,7 +30,25 @@ db.collection.find({
 | Parameter | Description |
 | --- | --- |
 | **`field`** | The name of the field in the output documents where the metadata gets included. |
-| **`metaDataKeyword`** | The type of metadata to include common keywords like `textScore` for text search scores. |
+| **`metaDataKeyword`** | The type of metadata to include. See the keywords below. |
+
+| Keyword | Returns |
+| --- | --- |
+| **`textScore`** | The relevance score of a `$text` search. |
+| **`searchScore`** | The similarity score of a [`$vectorSearch`](../aggregation/%24vectorsearch.md). |
+| **`vectorSearchScore`** | Alias for `searchScore`; the keyword MongoDB Atlas uses with `$vectorSearch`. |
+| **`indexKey`** | Not supported — rejected with `Returning indexKey for $meta not supported`. |
+
+Any other keyword is rejected with `Argument provided to the $meta is not supported: <keyword>`.
+
+`$meta` is not limited to `find()` projections — `searchScore` and `vectorSearchScore` are read from an aggregation `$project` stage following `$vectorSearch`:
+
+```javascript
+db.products.aggregate([
+  { $vectorSearch: { queryVector: [0.9, 0.1, 0.05], path: "embedding", limit: 2 } },
+  { $project: { _id: 0, name: 1, score: { $meta: "searchScore" } } }
+])
+```
 
 ## Examples
 

--- a/api-reference/operators/projection/$meta.md
+++ b/api-reference/operators/projection/$meta.md
@@ -173,4 +173,4 @@ The first two results returned by this query are:
 
 ## Limitation
 
-- If no index is used, the { $meta: "indexKey" } doesn't return anything.
+- `{ $meta: "indexKey" }` is not supported. It is rejected with `Returning indexKey for $meta not supported` whether or not the query uses an index.


### PR DESCRIPTION
Relates to documentdb/documentdb.github.io#130. First slice of the missing-stage gap; the remaining 10 stages are still undocumented.

## Why these four

The MQL reference documents **25** aggregation stages. `pg_documentdb` registers **40** public ones (`StageDefinitions[]` in `bson_aggregation_pipeline.c` holds 41 entries, one of which is `$_internalInhibitOptimization`), so **14** have no page at all.

These four are the ones a reader hits first:

- **`$vectorSearch`** — promoted on the documentdb.io `/ai` landing page, and `getting-started/python-setup.md` ships a working `$vectorSearch` pipeline for a stage that has no reference page. A reader who follows the AI page into getting-started and then wants the operator's parameters currently has nowhere to land.
- **`$graphLookup`** — also promoted on `/ai`: *"traverse related entities with `$graphLookup` in one query pipeline"*.
- **`$project`** and **`$limit`** — core stages.

## How the content was derived

Parameters, defaults, and constraints come from the upstream implementation, not from MongoDB's docs:

- `ParseAndValidateNativeVectorSearchSpec` (`bson_aggregation_search.c`) — the accepted `$vectorSearch` fields, the `numCandidates` bounds (`HNSW_MIN_EF_SEARCH`..`HNSW_MAX_EF_SEARCH` = 1..1000), the 16000-element cap on `queryVector`, and the fact that `index` is parsed but ignored.
- `ParseGraphLookupStage` (`bson_aggregation_nested_pipeline.c`) — the eight accepted `$graphLookup` parameters, which five are required, and the unbounded `maxDepth` default.
- `HandleLimit` (`bson_aggregation_pipeline.c`) — must be numeric, 64-bit representable, non-negative, non-zero.
  *Corrected in review:* the minimum rule holds only for adjacent `$limit` stages. `HandleLimit` sets `requiresSubQuery`, so stages nest rather than merge, and a document-multiplying stage between two `$limit`s breaks it.
- `bson_projection_tree.c` — the inclusion/exclusion mixing rule and the top-level `_id` exemption.

## Verification

Every example and every documented error message was executed against `documentdb-local` and its real output recorded. A clean-room replay then re-ran the whole set on a fresh database, asserting each documented result and error string:

```
--- $project ---        7 assertions
--- $limit ---          6 assertions
--- $graphLookup ---    8 assertions
--- $vectorSearch ---  14 assertions

RESULT: 35 passed, 0 failed
```

Every output block was produced by the engine, with one exception added during the review round: the unprojected `$vectorSearch` result showing `__cosmos_meta__` is derived from `AddScoreFieldToDocumentEntry` and the upstream expected-output files rather than from a run.

Two caveats on the numbers above. The suite predates the review round and has not been re-run against the current text. And it did not catch the `$project` Example 3 defect, because the assertion was written against the same fabricated sample document as the page — a replay is only as good as its fixture.

## One finding worth flagging

**`$vectorSearch.filter` requires an index on each field used in the filter**, not just on the embedding path. Without it the query fails outright rather than falling back to a scan:

```
The index for filter path 'category' was not found, please check whether the index is created.
```

The `/ai` landing page's `$vectorSearch` sample includes `filter: { category: "technical" }` with no mention of this, so it is the kind of thing a reader will hit immediately. The `$vectorSearch` page creates the filter index before using it, and documents the error.

Also, `numCandidates` is documented as choosing a default from the index's `efConstruction` and the collection size rather than a flat 40 — `GetDefaultSearchParamForIndex` picks between the two depending on `EnableVectorCalculateDefaultSearchParameter` and whether the collection is under the small-collection row threshold.

*Sharpened in review:* that threshold is a cliff, not a curve. `efConstruction` feeds the default only below `VECTOR_SEARCH_SMALL_COLLECTION_ROWS` (10,000); at or above it the default is a flat `HNSW_DEFAULT_EF_SEARCH` of 40, so an index built with `efConstruction: 512` silently searches at 40 on a 50,000-document collection. The page now states the threshold and recommends setting `numCandidates` by hand on production-sized collections.

## Review round

A source-validated review against `documentdb` upstream raised 22 findings; all are addressed in 21a7838, 8ee5fba and 0daa22a, and every thread is resolved with the specific change noted inline.

The substantive corrections, in rough order of how badly they would have misled a reader:

- **`$vectorSearch` returns an undocumented `__cosmos_meta__` field** on every document. Every example happened to hide it behind an inclusion `$project`, and an *exclusion* projection does not strip it — so an application round-tripping results would have persisted it silently.
- **`filter` was described as a true pre-filter with a `limit` guarantee.** The engine intersects an ANN scan with a separate filter query and applies `limit` to the join, so reaching `limit` is best-effort and depends on pgvector ≥ 0.8.0 iterative scan.
- **`$project` Example 3's output was wrong**, because the sample document invented a `tags` field and dropped `promotionEvents`. Now uses the canonical fixture.
- **`$graphLookup` claimed the `as` array order is undefined** while publishing three exact arrays as results. The page now documents the dedup-to-lowest-depth guarantee it was hiding.
- **Undocumented hard failures:** `$graphLookup` `from` cannot be sharded, `$vectorSearch` `filter` is rejected on sharded collections, and `restrictSearchWithMatch` rejects `$near` / `$nearSphere` / `$geoNear`.
- **Index constraints that were never stated:** `dimensions` is capped at 2000 without `compression`, not 16000 — which is exactly the wall a reader with 3072-dimension embeddings hits; and `efConstruction` must be at least `2 * m`.
- **`numCandidates` on `vector-ivf` does nothing** — accepted and validated, then dropped, because the IVF path reads only `nProbes`.

Also corrected outside the original diff: `$meta.md` claimed `{ $meta: "indexKey" }` returns nothing without an index; it is rejected unconditionally (0daa22a).

One review candidate was **refuted** rather than applied — a claimed inclusion/exclusion message swap, which traces to an unreachable ternary arm in `bson_projection_tree.c`.

## Conventions

Pages follow the existing `$addfields.md` structure — frontmatter, intro, `## Syntax`, `## Parameters`, `## Examples` with sample data, and a closing `## Related`. Filenames are lowercase to match the existing slugs. Every cross-link target was checked to exist. *Corrected in review:* the targets existed, but the link **form** was wrong — `../%24limit/` resolves one directory too high, into a path that holds only category folders. All 9 now use the same-directory `./%24name.md` form taken from the `$bucketauto.md` precedent. The repo has no link-checking CI, so this would have shipped silently.

## Still missing after this PR

`$replaceRoot`, `$setWindowFields`, `$unionWith`, `$search`, `$currentOp`, `$inverseMatch`, plus four that arguably do not warrant public pages: `$searchMeta`, `$listLocalSessions`, and `$listSessions` are registered with `.mutateFunc = NULL` and error unconditionally, and `$listSearchIndexes` is gated off by default (`DEFAULT_ENABLE_EXTENDED_INDEXES` is `false`).

Note also that `$replaceWith` is documented while `$replaceRoot` is not — in MongoDB `$replaceWith` is the *alias*, so the reference currently documents the alias and omits the canonical form. Upstream gives them separate handlers rather than treating them as aliases.
