### PR TITLE
Give the Kubernetes operator a home in the docs, and point it at its own

### DIFF
--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -71,6 +71,7 @@ Choose the getting started guide that best fits your needs:
 
 ### Deployment Options
 - [Pre-built Packages](https://documentdb.io/docs/getting-started/prebuilt-packages/) - Download and install ready-to-use packages
+- [Kubernetes Operator](https://documentdb.io/docs/kubernetes-operator/) - Run DocumentDB as a replicated service on Kubernetes
 
 ## Community and Support
 

--- a/kubernetes-operator/index.md
+++ b/kubernetes-operator/index.md
@@ -1,0 +1,44 @@
+---
+title: Kubernetes Operator
+description: Run DocumentDB on Kubernetes with the DocumentDB Kubernetes Operator. Learn when to choose it, what your cluster needs, and where to find the operator's documentation.
+---
+
+# Kubernetes Operator
+
+The [DocumentDB Kubernetes Operator](https://github.com/documentdb/documentdb-kubernetes-operator) runs and manages DocumentDB clusters on Kubernetes. You describe a cluster as a `DocumentDB` resource, and the operator provisions it and handles high availability, failover, backups, and upgrades, building on [CloudNativePG](https://cloudnative-pg.io/docs/) for the PostgreSQL layer. Every instance pairs a PostgreSQL container with a DocumentDB gateway sidecar, so applications connect using MongoDB-compatible drivers exactly as they would to any other DocumentDB deployment.
+
+The operator is a separate project, with its own repository, release cadence, and documentation. This page covers when to reach for it and what your cluster needs; the operator's own documentation covers everything else.
+
+## When to use it
+
+| Option | Best for |
+|---|---|
+| [DocumentDB Local](https://documentdb.io/docs/documentdb-local/) | A single container for development, prototyping, and integration tests. |
+| [Pre-built packages](https://documentdb.io/docs/getting-started/prebuilt-packages/) | Adding DocumentDB to a PostgreSQL server you already run and operate yourself. |
+| Kubernetes Operator | Running DocumentDB as a replicated service, with automatic failover, rolling upgrades, backup and restore, and multi-region deployments. |
+
+## What your cluster needs
+
+Check one thing before you plan a deployment. The operator mounts the DocumentDB extension into PostgreSQL pods using the Kubernetes [ImageVolume](https://kubernetes.io/docs/concepts/storage/volumes/#image) feature, which constrains where it can run:
+
+- **Kubernetes 1.35 or later**, where ImageVolume is generally available. On 1.33 and 1.34 the feature is beta, and works only if you enable the `ImageVolume` feature gate on the API server and the kubelets.
+- **containerd or CRI-O** as the container runtime. The Docker runtime does not support ImageVolume.
+
+If the feature is unavailable, the operator's admission webhook rejects the `DocumentDB` resource with an explanatory error rather than leaving pods stuck. Managed Kubernetes offerings vary in the versions and runtimes they expose, and local tools often need an explicit flag to select a supported runtime, so confirm both up front. [Before You Start](https://documentdb.io/documentdb-kubernetes-operator/latest/preview/getting-started/before-you-start/) has the full prerequisite list, including supported tooling versions and resource sizing.
+
+## Operator documentation
+
+The operator's documentation is versioned and published alongside its releases:
+
+- [Overview](https://documentdb.io/documentdb-kubernetes-operator/latest/preview/) — what the operator installs and how the pieces fit together
+- [Quickstart: Kind](https://documentdb.io/documentdb-kubernetes-operator/latest/preview/getting-started/quickstart-kind/) and [Quickstart: K3s](https://documentdb.io/documentdb-kubernetes-operator/latest/preview/getting-started/quickstart-k3s/) — deploy a cluster locally
+- [Connecting to DocumentDB](https://documentdb.io/documentdb-kubernetes-operator/latest/preview/getting-started/connecting-to-documentdb/) — `mongosh` and driver examples for Python, Node.js, Go, and Java
+- [Architecture overview](https://documentdb.io/documentdb-kubernetes-operator/latest/preview/architecture/overview/) — how the operator, CloudNativePG, and the gateway interact
+- Configuration: [networking](https://documentdb.io/documentdb-kubernetes-operator/latest/preview/configuration/networking/), [storage](https://documentdb.io/documentdb-kubernetes-operator/latest/preview/configuration/storage/), and [TLS](https://documentdb.io/documentdb-kubernetes-operator/latest/preview/configuration/tls/)
+- [High availability](https://documentdb.io/documentdb-kubernetes-operator/latest/preview/high-availability/overview/) — replicas, failover behavior, and recovery objectives
+- Operations: [backup and restore](https://documentdb.io/documentdb-kubernetes-operator/latest/preview/operations/backup-and-restore/) and [upgrades](https://documentdb.io/documentdb-kubernetes-operator/latest/preview/operations/upgrades/)
+- [Monitoring](https://documentdb.io/documentdb-kubernetes-operator/latest/preview/monitoring/overview/) and the [kubectl plugin](https://documentdb.io/documentdb-kubernetes-operator/latest/preview/kubectl-plugin/)
+- [API reference](https://documentdb.io/documentdb-kubernetes-operator/latest/preview/api-reference/) — the `DocumentDB`, `Backup`, and `ScheduledBackup` resources
+- [FAQ](https://documentdb.io/documentdb-kubernetes-operator/latest/preview/faq/)
+
+Report operator issues in the [operator repository](https://github.com/documentdb/documentdb-kubernetes-operator/issues) rather than this one.

--- a/kubernetes-operator/navigation.yml
+++ b/kubernetes-operator/navigation.yml
@@ -1,0 +1,2 @@
+- title: Kubernetes Operator
+  link: index.md

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Welcome to the official documentation for [DocumentDB](https://github.com/docume
 - [PostgreSQL API](postgres-api/index.md) - PostgreSQL-compatible API documentation
 - [Architecture](architecture/index.md) - System architecture and design principles
 - [documentdb-local](documentdb-local/index.md) - Detailed documentation of the documentdb-local container image
-- [DocumentDB Kubernetes Operator](https://documentdb.io/documentdb-kubernetes-operator) - Documentation for the DocumentDB Kubernetes Operator
+- [Kubernetes Operator](kubernetes-operator/index.md) - Running DocumentDB on Kubernetes, and where to find the operator's own documentation
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Kubernetes is close to invisible in this repository. Before this change, the only mention anywhere is a single link in `readme.md` — so a reader browsing the documentation site sees VS Code, Python, Node.js, mongosh, and pre-built packages, with no sign that DocumentDB runs on Kubernetes at all.

This adds a `kubernetes-operator` section that orients the reader and hands off to the operator's own documentation.

## What changed

- **New top-level `kubernetes-operator/` section** — a single `index.md` plus `navigation.yml`, the same shape `documentdb-local/` and `architecture/` already use. It sits alongside `documentdb-local` rather than nested under `getting-started`, because the two are the same kind of thing (a way to run DocumentDB) and the docs landing page enumerates top-level sections.
- **Cross-links in** from the getting-started landing page under Deployment Options, and from the readme.

## Why it links rather than duplicates

The operator is a separate project publishing around thirty pages of its own — quickstarts, configuration, high availability, operations, monitoring, API reference — versioned with its releases and edited in the same pull requests that change the operator's behavior. A copy kept here is a second copy maintained against a moving target, in a different publishing system, without the version scoping that makes the original correct.

#1 shows the cost. It was an accurate operator quickstart when it was opened, and since then its API group (`db.microsoft.com`, now `documentdb.io`) and its chart registry (`ghcr.io/microsoft`, now `ghcr.io/documentdb`) have both moved — either one enough to stop the walkthrough at its first command. The operator's own quickstart followed both changes as they landed.

So the page carries only what a reader needs in order to choose: what the operator does, how it compares with DocumentDB Local and the pre-built packages, and the one prerequisite that decides whether it can run at all — the ImageVolume feature, which pins the cluster to Kubernetes 1.35+ (or 1.33/1.34 with the feature gate) on containerd or CRI-O, and which the operator's admission webhook now enforces at resource creation. Everything past that decision is a deep link. No manifests, no install commands, no resource fields: those are exactly what went stale before.

## Verification

Every outbound link was checked against the live site, including a deliberate non-existent control URL to confirm the check distinguishes real pages from soft 404s. The prerequisite claims were checked against the operator source rather than its prose.

## Follow-ups, not in this PR

- #1 should be closed; it has a comment explaining why.
- Two items live in `documentdb.github.io` and need a separate PR there: the `/docs` landing entry for Kubernetes points at the marketing page rather than any documentation, and that page's install snippet uses the classic chart repo, which tops out at chart 0.2.0 (published 2026-03-26) while the current chart is 0.3.0 and the operator has moved to the OCI registry.
