### PR TITLE
Finish wiring up the kubernetes-operator section

### DIFF
--- a/documentdb-local/index.md
+++ b/documentdb-local/index.md
@@ -170,6 +170,14 @@ For mongosh info see: https://www.mongodb.com/docs/mongodb-shell/
 ```
 
 
+## Beyond local development
+
+DocumentDB Local runs a single container on one machine, with no replication and no failover, which is what makes it convenient for development and testing. For other ways to run DocumentDB:
+
+- [Kubernetes Operator](https://documentdb.io/docs/kubernetes-operator/) - run DocumentDB as a replicated service, with automatic failover, backup and restore, and rolling upgrades.
+- [Pre-built packages](https://documentdb.io/docs/getting-started/prebuilt-packages/) - add the DocumentDB extension to a PostgreSQL server you already run.
+
+
 ## Reporting issues
 
 If you encounter issues with using this version of DocumentDB, open an issue in the GitHub repository (<https://github.com/documentdb/documentdb/issues>) and tag it with the label `documentdb-local`.

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,7 @@ Documentation articles are stored in the following folders:
 - `/architecture`
 - `/documentdb-local`
 - `/getting-started`
+- `/kubernetes-operator`
 - `/postgres-api`
 
 Each folder contains Markdown files (*\*.md*) and a *navigation.yml* file. Markdown files require the following YAML front matter metadata:


### PR DESCRIPTION
## Summary

Two loose ends from #62. Both exist because pull requests merged independently of each other and could not have known about each other — neither is a defect in the PRs that created them.

## The contributing instructions name four folders where there are five

#35 added the Articles section to `readme.md`, listing the folders that hold documentation articles. It was written while #62 was still open, so `/kubernetes-operator` is missing from the list even though it is now a section like any other, with a `navigation.yml` and the same front matter requirements. A contributor following those instructions would not know it exists.

## The documentdb-local page has no route onward

Someone who has just run the container and now wants replication, failover, or rolling upgrades has no reason to guess that the answer lives in a different section of the site. That page is the most likely place in these docs for the question to come up, so it now points at the operator section and at the pre-built packages.

This was deliberately held back while #61 was rewriting `documentdb-local/index.md`, to avoid handing that PR a conflict. #61 has merged, so it lands now.
