### PR TITLE
Use link targets that resolve for the aggregation cross-references

### DIFF
--- a/api-reference/operators/aggregation/$graphlookup.md
+++ b/api-reference/operators/aggregation/$graphlookup.md
@@ -216,5 +216,5 @@ The `maxDepth` message contains a non-breaking hyphen (U+2011) rather than an AS
 
 ## Related
 
-- [`$lookup`](./%24lookup.md) — joins a single level instead of recursing.
-- [`$unwind`](./%24unwind.md) — flattens the array produced in the `as` field.
+- [`$lookup`](https://documentdb.io/docs/reference/operators/aggregation/%24lookup/) — joins a single level instead of recursing.
+- [`$unwind`](https://documentdb.io/docs/reference/operators/aggregation/%24unwind/) — flattens the array produced in the `as` field.

--- a/api-reference/operators/aggregation/$limit.md
+++ b/api-reference/operators/aggregation/$limit.md
@@ -124,5 +124,5 @@ A value that cannot be represented as a 64-bit integer is also rejected.
 
 ## Related
 
-- [`$skip`](./%24skip.md) — skips documents instead of truncating the result.
-- [`$sort`](./%24sort.md) — order documents before limiting them.
+- [`$skip`](https://documentdb.io/docs/reference/operators/aggregation/%24skip/) — skips documents instead of truncating the result.
+- [`$sort`](https://documentdb.io/docs/reference/operators/aggregation/%24sort/) — order documents before limiting them.

--- a/api-reference/operators/aggregation/$project.md
+++ b/api-reference/operators/aggregation/$project.md
@@ -183,7 +183,7 @@ The DBRef field names `$id`, `$ref`, and `$db` are exempt, so `{ $project: { "$i
 
 ## Related
 
-- [`$addFields`](./%24addfields.md) — adds fields while keeping all existing ones.
-- [`$set`](./%24set.md) — alias for `$addFields`.
-- [`$unset`](./%24unset.md) — removes fields without switching the whole stage to exclusion semantics.
-- [`$meta`](../projection/%24meta.md) — surface search metadata, such as a `$vectorSearch` similarity score, as a projected field.
+- [`$addFields`](https://documentdb.io/docs/reference/operators/aggregation/%24addfields/) — adds fields while keeping all existing ones.
+- [`$set`](https://documentdb.io/docs/reference/operators/aggregation/%24set/) — alias for `$addFields`.
+- [`$unset`](https://documentdb.io/docs/reference/operators/aggregation/%24unset/) — removes fields without switching the whole stage to exclusion semantics.
+- [`$meta`](https://documentdb.io/docs/reference/operators/projection/%24meta/) — surface search metadata, such as a `$vectorSearch` similarity score, as a projected field.

--- a/api-reference/operators/aggregation/$search.md
+++ b/api-reference/operators/aggregation/$search.md
@@ -11,7 +11,7 @@ The `$search` stage in the aggregation pipeline runs a vector similarity search 
 
 `$search` must be the first stage in the pipeline, and the field named by `path` must be covered by a vector index.
 
-> `$search` in DocumentDB is a vector search stage. It does not accept text-search operators: a spec such as `{ $search: { text: { ... } } }` is rejected with `Unrecognized $search option: text`. For full-text queries, use the `$text` query operator against a text index. For new work, prefer [`$vectorSearch`](./%24vectorsearch.md), which is the current stage for vector search and takes a clearer spec; `$search` remains for compatibility with existing `cosmosSearch` and `knnBeta` queries.
+> `$search` in DocumentDB is a vector search stage. It does not accept text-search operators: a spec such as `{ $search: { text: { ... } } }` is rejected with `Unrecognized $search option: text`. For full-text queries, use the `$text` query operator against a text index. For new work, prefer [`$vectorSearch`](https://documentdb.io/docs/reference/operators/aggregation/%24vectorsearch/), which is the current stage for vector search and takes a clearer spec; `$search` remains for compatibility with existing `cosmosSearch` and `knnBeta` queries.
 
 ## Syntax
 
@@ -121,10 +121,10 @@ db.products.aggregate([
 
 - **`$search` must come first.** Placing it anywhere else fails with `$search must appear as the initial stage in the pipeline sequence.` The same applies when the pipeline already carries a limit ahead of it.
 - **One operator per spec.** The stage rejects a spec carrying more than one search operator, and a spec carrying none.
-- **`path` must be indexed.** The field named by `path` must be covered by a vector index; see [`$vectorSearch`](./%24vectorsearch.md) for creating one.
+- **`path` must be indexed.** The field named by `path` must be covered by a vector index; see [`$vectorSearch`](https://documentdb.io/docs/reference/operators/aggregation/%24vectorsearch/) for creating one.
 
 ## Related content
 
-- [`$vectorSearch`](./%24vectorsearch.md) — the current vector search stage, and the one to prefer for new queries.
-- [`$project`](./%24project.md) — shape the documents returned by the search.
-- [`$limit`](./%24limit.md) — narrow the result set further; `k` already bounds it.
+- [`$vectorSearch`](https://documentdb.io/docs/reference/operators/aggregation/%24vectorsearch/) — the current vector search stage, and the one to prefer for new queries.
+- [`$project`](https://documentdb.io/docs/reference/operators/aggregation/%24project/) — shape the documents returned by the search.
+- [`$limit`](https://documentdb.io/docs/reference/operators/aggregation/%24limit/) — narrow the result set further; `k` already bounds it.

--- a/api-reference/operators/aggregation/$vectorsearch.md
+++ b/api-reference/operators/aggregation/$vectorsearch.md
@@ -326,6 +326,6 @@ Documents returned by `$vectorSearch` carry an internal `__cosmos_meta__` field 
 
 ## Related
 
-- [`$limit`](./%24limit.md) — `$vectorSearch` takes its own `limit`; a later `$limit` can narrow the result further.
-- [`$project`](./%24project.md) — shape the results, and surface the similarity score with `$meta`.
-- [`$meta`](../projection/%24meta.md) — the metadata operator used to project `searchScore`.
+- [`$limit`](https://documentdb.io/docs/reference/operators/aggregation/%24limit/) — `$vectorSearch` takes its own `limit`; a later `$limit` can narrow the result further.
+- [`$project`](https://documentdb.io/docs/reference/operators/aggregation/%24project/) — shape the results, and surface the similarity score with `$meta`.
+- [`$meta`](https://documentdb.io/docs/reference/operators/projection/%24meta/) — the metadata operator used to project `searchScore`.

--- a/api-reference/operators/projection/$meta.md
+++ b/api-reference/operators/projection/$meta.md
@@ -35,7 +35,7 @@ db.collection.find({
 | Keyword | Returns |
 | --- | --- |
 | **`textScore`** | The relevance score of a `$text` search. |
-| **`searchScore`** | The similarity score of a [`$vectorSearch`](../aggregation/%24vectorsearch.md). |
+| **`searchScore`** | The similarity score of a [`$vectorSearch`](https://documentdb.io/docs/reference/operators/aggregation/%24vectorsearch/). |
 | **`vectorSearchScore`** | Alias for `searchScore`; the keyword MongoDB Atlas uses with `$vectorSearch`. |
 | **`indexKey`** | Not supported — rejected with `Returning indexKey for $meta not supported`. |
 


### PR DESCRIPTION
## Summary

Seventeen cross-reference links across six pages point at relative `.md` paths, and every one of them 404s.

On `$search`, the link to `$vectorSearch` renders as:

```html
href="./%24vectorsearch.md"
```

documentdb.io serves these pages with a trailing slash, so that resolves against the page's own directory and lands at `/operators/aggregation/$search/%24vectorsearch.md` — wrong depth **and** a leaked extension, the two failure modes #57 catalogued, in a single href. Confirmed 404 against the live site.

## Affected

| File | Links |
| --- | --- |
| `$search.md` | 5 |
| `$project.md` | 4 |
| `$vectorsearch.md` | 3 |
| `$graphlookup.md` | 2 |
| `$limit.md` | 2 |
| `$meta.md` | 1 |

They were introduced together: `$vectorSearch`, `$project`, `$limit` and `$graphLookup` arrived in #59, `$search` in #64 following the convention it found on the page beside it, and `$meta` links back the same way. None of them render, so those pages read as cross-linked while every cross-link is dead.

## Fix

Rewritten to the absolute form the rest of the reference already uses:

```
https://documentdb.io/docs/reference/operators/aggregation/%24bucket/
```

That is what #57 settled on for exactly this reason — it does not depend on how the site resolves a relative path, and it survives a page moving between directories.

## Verification

All 13 distinct targets were requested against the live site and return **200**. No relative `.md` link remains anywhere in the repository:

```
$ grep -rn '](\.\{1,2\}/[^)]*\.md)' --include="*.md" . | wc -l
0
```

Related: this is the class of documentdb/docs#38, which stays open for the wider `.md`-in-links question.
