### PR TITLE
Document $inverseMatch, and close out the missing-stages list

### DIFF
--- a/api-reference/operators/aggregation/$inversematch.md
+++ b/api-reference/operators/aggregation/$inversematch.md
@@ -1,0 +1,156 @@
+---
+title: $inverseMatch
+description: The $inverseMatch stage in the aggregation pipeline keeps documents whose stored query matches a supplied document, inverting the usual direction of a match.
+type: operators
+category: aggregation
+---
+
+# $inverseMatch
+
+The `$inverseMatch` stage in the aggregation pipeline inverts the usual direction of a match. Where `$match` holds one query and tests it against many documents, `$inverseMatch` reads a query *out of* each document and tests it against one supplied input. A document survives the stage when the query it carries matches that input.
+
+That makes it the stage for collections of stored queries — saved searches, alert rules, subscription filters, routing policies — where the question is not "which documents match this query" but "which stored queries match this document".
+
+`$inverseMatch` is specific to DocumentDB and has no MongoDB equivalent.
+
+## Syntax
+
+The stage takes the input to test in one of two forms. Either supply it inline with `input`:
+
+```javascript
+{
+  $inverseMatch: {
+    path: <string>,
+    input: <expression>,
+    defaultResult: <boolean>
+  }
+}
+```
+
+Or read it from another collection with `from` and `pipeline`:
+
+```javascript
+{
+  $inverseMatch: {
+    path: <string>,
+    from: <string>,
+    pipeline: [ <stage>, ... ],
+    defaultResult: <boolean>
+  }
+}
+```
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| **`path`** | Required. The dotted path at which each document stores its query. Omitting it fails with `Path parameter is missing for the operator $inverseMatch`. |
+| **`input`** | The document to test the stored queries against. Must be a constant value or a string path expression such as `"$payload"` — anything else fails with `$inverseMatch expects 'input' to be a constant value or a string path expression.` It has to resolve to a document or an array of documents. Mutually exclusive with `from`. |
+| **`from`** | The collection to read input documents from, as a string. Requires `pipeline`. Mutually exclusive with `input`. |
+| **`pipeline`** | Required when `from` is set. The pipeline run against `from` to produce the input documents. Only `$match`, `$project` and `$limit` may appear in it. |
+| **`defaultResult`** | Optional boolean, default `false`. The result used for a document that has no value at `path` — `false` drops it, `true` keeps it. |
+
+Exactly one of `input` or `from` must be present. Any other key is rejected with `Unrecognized parameter supplied to $inverseMatch: '<name>'`.
+
+## Examples
+
+The examples use an `alerts` collection, where each document stores the query that defines the alert:
+
+```json
+[
+  { "_id": 1, "name": "High value orders", "criteria": { "total": { "$gt": 500 } } },
+  { "_id": 2, "name": "Electronics", "criteria": { "category": "electronics" } },
+  { "_id": 3, "name": "Bulk orders", "criteria": { "quantity": { "$gte": 10 } } },
+  { "_id": 4, "name": "Unfiltered" }
+]
+```
+
+### Example 1: Which stored queries match this document
+
+Find the alerts that a single order would trigger:
+
+```javascript
+db.alerts.aggregate([
+  {
+    $inverseMatch: {
+      path: "criteria",
+      input: { total: 750, category: "electronics", quantity: 2 }
+    }
+  },
+  { $project: { name: 1 } }
+])
+```
+
+```json
+[
+  { "_id": 1, "name": "High value orders" },
+  { "_id": 2, "name": "Electronics" }
+]
+```
+
+Alert 3 is dropped because the order's `quantity` is below its threshold, and alert 4 because it has no `criteria` field at all — `defaultResult` is `false` by default.
+
+### Example 2: Keeping documents that store no query
+
+Set `defaultResult` to `true` to treat a missing query as a match, which is how you model a catch-all rule:
+
+```javascript
+db.alerts.aggregate([
+  {
+    $inverseMatch: {
+      path: "criteria",
+      input: { total: 750, category: "electronics", quantity: 2 },
+      defaultResult: true
+    }
+  },
+  { $project: { name: 1 } }
+])
+```
+
+```json
+[
+  { "_id": 1, "name": "High value orders" },
+  { "_id": 2, "name": "Electronics" },
+  { "_id": 4, "name": "Unfiltered" }
+]
+```
+
+### Example 3: Taking the input from another collection
+
+Use `from` and `pipeline` to test the stored queries against a document held elsewhere, rather than one written into the stage:
+
+```javascript
+db.alerts.aggregate([
+  {
+    $inverseMatch: {
+      path: "criteria",
+      from: "orders",
+      pipeline: [
+        { $match: { _id: 4001 } },
+        { $project: { total: 1, category: 1, quantity: 1, _id: 0 } },
+        { $limit: 1 }
+      ]
+    }
+  },
+  { $project: { name: 1 } }
+])
+```
+
+The pipeline is restricted to `$match`, `$project` and `$limit`. Any other stage fails with:
+
+```
+<stage> is not allowed to be used within an $inverseMatch stage, only $match, $project or $limit are allowed
+```
+
+## Behavior
+
+- **The stored value must be a query document.** If the value at `path` is present but is not a document, the stage errors rather than skipping the document.
+- **A missing path is not an error.** When a document has no value at `path`, the stage uses `defaultResult` — `false` unless you set it otherwise — so those documents are dropped silently by default.
+- **`input` is an expression, not just a literal.** A string is treated as a path expression, so `input: "$payload"` tests each stored query against that document's own `payload` field. To pass a literal document, write it inline as in the examples above.
+- **`input` may be an array.** An array of documents is accepted as well as a single document.
+
+## Related content
+
+- [`$match`](https://documentdb.io/docs/reference/operators/aggregation/%24match/) — the usual direction: one query, many documents.
+- [`$project`](https://documentdb.io/docs/reference/operators/aggregation/%24project/) — shape the surviving documents.
+- [`$limit`](https://documentdb.io/docs/reference/operators/aggregation/%24limit/) — one of the three stages permitted inside `pipeline`.


### PR DESCRIPTION
Addresses the remainder of documentdb/documentdb.github.io#130. Nine of the fourteen stages it listed were documented in #59 and #64; this covers the five that were left, though not in the way the issue expects — **only one of them can currently be run.**

## The one that ships: `$inverseMatch`

Implemented, ungated, and specific to DocumentDB — there is no MongoDB equivalent, so a reader who meets it in a pipeline has nowhere else to look. That makes it the highest-value page of the original fourteen.

The stage inverts the direction of a match: `$match` holds one query and tests it against many documents, while `$inverseMatch` reads a query *out of* each document and tests it against a supplied input. It is the stage for collections of stored queries — saved searches, alert rules, subscription filters.

Documented from `ParseInverseMatchSpec` and the operator implementation: required `path`, mutually exclusive `input` / `from`, `pipeline` required alongside `from` and restricted to `$match`, `$project` and `$limit`, and `defaultResult` governing documents that carry no query. Two behaviours got explicit space because both are quietly surprising — a missing `path` is not an error but a silent drop unless `defaultResult` says otherwise, and `input` is parsed as an aggregation expression, so a bare string is a path reference rather than a literal document.

## The four that do not: no pages, deliberately

| Stage | Why not |
| --- | --- |
| `$listLocalSessions` | `.mutateFunc = NULL` |
| `$listSessions` | `.mutateFunc = NULL` |
| `$searchMeta` | `.mutateFunc = NULL` |
| `$listSearchIndexes` | Feature-flagged off, and its rewrite hook is unset in this build |

A stage registered with a null handler is rejected by the pipeline builder itself (`bson_aggregation_pipeline.c:9019`):

```c
if (definition->mutateFunc == NULL)
    ereport(ERROR, (errcode(ERRCODE_DOCUMENTDB_COMMANDNOTSUPPORTED),
        errmsg("Stage %s is not supported yet in native pipeline", definition->stage)));
```

`$listSearchIndexes` fails twice over. `documentdb.enableExtendedIndexes` defaults to `false` (`feature_flag_configs.c:214`), so it errors `$listSearchIndexes stage is not enabled` out of the box; and even with the flag on, `rewrite_list_extended_indexes_query_hook` is `NULL` in this build (`api_hooks.c:47`), so the handler's `RewriteListExtendedIndexesQuery` returns `NULL` and it errors `$listSearchIndexes is not supported`. It is an extension point for a downstream distribution, not a stage this engine can run.

Writing reference pages for these four would repeat the mistake #64 had to correct on `$search`: documenting MongoDB's behaviour for something DocumentDB does not implement, in a form that looks authoritative and fails on first use.

## A note on the count

Issue #130 derived "40 public stages" from `StageDefinitions[]`, and its own analysis warned that the table "gives a name and a `.mutateFunc` pointer, and says nothing about what the stage accepts". That caveat applies to the **count** as well: at least four entries in the table cannot be executed. The gap was smaller than it looked.

## Verification

Every claim here comes from the engine source at `v0.114-0`, not from MongoDB's documentation. The three outbound links on the new page were checked against the live site and return 200.
